### PR TITLE
Capture app output in silent mode.

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -63,7 +63,7 @@ func renderHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	buf, err := loader.RenderApplet(r.Path, r.Config, r.Width, r.Height, r.Magnify, maxDuration, timeout, imageFormat, silenceOutput)
+	buf, _, err := loader.RenderApplet(r.Path, r.Config, r.Width, r.Height, r.Magnify, maxDuration, timeout, imageFormat, silenceOutput)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("error rendering: %v", err), http.StatusInternalServerError)
 		return

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -150,7 +150,7 @@ func render(cmd *cobra.Command, args []string) error {
 	runtime.InitHTTP(cache)
 	runtime.InitCache(cache)
 
-	buf, err := loader.RenderApplet(path, config, width, height, magnify, maxDuration, timeout, imageFormat, silenceOutput)
+	buf, _, err := loader.RenderApplet(path, config, width, height, magnify, maxDuration, timeout, imageFormat, silenceOutput)
 	if err != nil {
 		return fmt.Errorf("error rendering: %w", err)
 	}

--- a/library/library.go
+++ b/library/library.go
@@ -34,7 +34,7 @@ func render_app(pathPtr *C.char, configPtr *C.char, width, height, magnify, maxD
 		return nil, -1
 	}
 
-	result, err := loader.RenderApplet(path, config, int(width), int(height), int(magnify), int(maxDuration), int(timeout), loader.ImageFormat(imageFormat), silenceOutput != 0)
+	result, _, err := loader.RenderApplet(path, config, int(width), int(height), int(magnify), int(maxDuration), int(timeout), loader.ImageFormat(imageFormat), silenceOutput != 0)
 	if err != nil {
 		fmt.Printf("error rendering: %v\n", err)
 		return nil, -2


### PR DESCRIPTION
This can be used to capture the output of an app without writing it to stdout. Libpixlet will be changed in a follow-up PR to make the output available for display in a web app, for example.