### PR TITLE
Fix release link to point to tronbyt releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ dist/
 # Dependency directories
 node_modules
 src/go
+
+.vscode/

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Download the `pixlet` binary from [the latest release][1].
 
 Alternatively you can [build from source](docs/BUILD.md).
 
-[1]: https://github.com/tidbyt/pixlet/releases/latest
+[1]: https://github.com/tronbyt/pixlet/releases/latest
 
 ### Hello, World!
 


### PR DESCRIPTION
I got stuck making a new app when I downloaded Tidbyt V 33 instead of Tronbyt V 44.  Just making this easier for other new users