### PR TITLE
chore(deps): update go to v1.25.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.1"
+          go-version: "1.25.3"
 
       - name: Install buildifier
         run: make install-buildifier
@@ -43,7 +43,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.1"
+          go-version: "1.25.3"
 
       - name: Install Node
         uses: actions/setup-node@v5

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.1"
+          go-version: "1.25.3"
 
       - name: Install buildifier
         run: make install-buildifier
@@ -37,7 +37,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.1"
+          go-version: "1.25.3"
 
       - name: Install Node
         uses: actions/setup-node@v5

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN npm run build
 # Can't use Alpine because of
 # - https://github.com/golang/go/issues/54805: libpixlet.so can't be loaded dynamically
 # - https://github.com/python/cpython/issues/109332: CPython doesn't support musl
-FROM --platform=$BUILDPLATFORM golang:1.25.1 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.3 AS builder
 WORKDIR /pixlet
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module tidbyt.dev/pixlet
 
-go 1.25.1
+go 1.25.3
 
 require (
 	github.com/Code-Hex/Neo-cowsay/v2 v2.0.4


### PR DESCRIPTION
Updates Go version to v1.25.2, which includes some security fixes.

> go1.25.2 (released 2025-10-07) includes security fixes to the archive/tar, crypto/tls, crypto/x509, encoding/asn1, encoding/pem, net/http, net/mail, net/textproto, and net/url packages, as well as bug fixes to the compiler, the runtime, and the context, debug/pe, net/http, os, and sync/atomic packages. See the [Go 1.25.2 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.25.2+label%3ACherryPickApproved) on our issue tracker for details.
>
> go1.25.3 (released 2025-10-13) includes fixes to the crypto/x509 package. See the [Go 1.25.3 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.25.3+label%3ACherryPickApproved) on our issue tracker for details.