### PR TITLE
feat(emoji): add width param, make height optional, improve scaling

### DIFF
--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -164,12 +164,13 @@ used in text rendering.
 | Name | Type | Description | Required |
 | --- | --- | --- | --- |
 | `emoji` | `str` |  | **Y** |
-| `height` | `int` | Desired height in pixels (width will be calculated to maintain aspect ratio) | **Y** |
+| `width` | `int` | Scale emoji to this width | N |
+| `height` | `int` | Scale emoji to this height | N |
 
 
 #### Example
 ```
-render.Emoji(emoji="😀", height=32)  // Large smiley face
+render.Emoji(emoji="😀", height=32) // Large smiley face
 ```
 ![](img/widget_Emoji_0.gif)
 

--- a/render/emoji_test.go
+++ b/render/emoji_test.go
@@ -12,6 +12,9 @@ func scaledWidth(seq string, height int) int {
 	if !ok || glyph.Empty() {
 		return height
 	}
+	if height == 0 {
+		return glyph.Dx()
+	}
 	innerH := glyph.Dy()
 	if innerH == 0 {
 		return height
@@ -72,7 +75,7 @@ func TestEmojiWidget(t *testing.T) {
 			name:    "zero height",
 			emoji:   "😀",
 			height:  0,
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name:    "negative height",
@@ -109,7 +112,7 @@ func TestEmojiWidget(t *testing.T) {
 
 				// Verify image has correct dimensions
 				width, height := emoji.Size()
-				if height != tt.height {
+				if tt.height != 0 && height != tt.height {
 					t.Errorf("Expected height %d, got %d", tt.height, height)
 				}
 

--- a/runtime/modules/render_runtime/generated.go
+++ b/runtime/modules/render_runtime/generated.go
@@ -726,6 +726,7 @@ func newEmoji(
 
 	var (
 		emoji  starlark.String
+		width  starlark.Int
 		height starlark.Int
 	)
 
@@ -733,7 +734,8 @@ func newEmoji(
 		"Emoji",
 		args, kwargs,
 		"emoji", &emoji,
-		"height", &height,
+		"width?", &width,
+		"height?", &height,
 	); err != nil {
 		return nil, fmt.Errorf("unpacking arguments for Emoji: %s", err)
 	}
@@ -741,6 +743,8 @@ func newEmoji(
 	w := &Emoji{}
 
 	w.EmojiStr = emoji.GoString()
+
+	w.Width = int(width.BigInt().Int64())
 
 	w.Height = int(height.BigInt().Int64())
 
@@ -761,7 +765,7 @@ func (w *Emoji) AsRenderWidget() render.Widget {
 
 func (w *Emoji) AttrNames() []string {
 	return []string{
-		"emoji", "height",
+		"emoji", "width", "height",
 	}
 }
 
@@ -771,6 +775,10 @@ func (w *Emoji) Attr(name string) (starlark.Value, error) {
 	case "emoji":
 
 		return starlark.String(w.EmojiStr), nil
+
+	case "width":
+
+		return starlark.MakeInt(int(w.Width)), nil
 
 	case "height":
 


### PR DESCRIPTION
This PR changes `render.Emoji` to automatically load the glyph's width/height if no value is provided. It also adds an optional `width` parameter. Lastly, the scaling algorithm has been updated to keep the glyph as clear as possible:
1. If the scale is 1:1, it uses nearest-neighbor interpolation. This will result in the clearest image.
2. Otherwise, it scales up using nearest-neighbor interpolation, then scales down to the final size using lanczos2. This improves the final result since the interpolation will never need to "invent" pixels.