### PR TITLE
feat: add native support for 2x rendering

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -38,6 +38,7 @@ type renderRequest struct {
 	Height      int               `json:"height"`
 	Magnify     int               `json:"magnify"`
 	ColorFilter string            `json:"color_filter,omitempty"`
+	Output2x    bool              `json:"2x,omitempty"`
 }
 
 func validatePath(path string) bool {
@@ -75,6 +76,7 @@ func renderHandler(w http.ResponseWriter, req *http.Request) {
 	filters := &encode.RenderFilters{
 		Magnify:     r.Magnify,
 		ColorFilter: filterType,
+		Output2x:    r.Output2x,
 	}
 
 	buf, _, err := loader.RenderApplet(r.Path, r.Config, r.Width, r.Height, r.Magnify, maxDuration, timeout, imageFormat, silenceOutput, filters)

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -26,6 +26,7 @@ var (
 	timeout           int
 	colorFilter       string
 	listColorFilters  bool
+	output2x          bool
 )
 
 func init() {
@@ -79,6 +80,13 @@ func init() {
 		"list-color-filters",
 		false,
 		"List available color filters",
+	)
+	RenderCmd.Flags().BoolVarP(
+		&output2x,
+		"2x",
+		"2",
+		false,
+		"Render at 2x resolution",
 	)
 }
 
@@ -180,6 +188,7 @@ func render(cmd *cobra.Command, args []string) error {
 	filters := &encode.RenderFilters{
 		Magnify:     magnify,
 		ColorFilter: filterType,
+		Output2x:    output2x,
 	}
 
 	buf, _, err := loader.RenderApplet(path, config, width, height, magnify, maxDuration, timeout, imageFormat, silenceOutput, filters)

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -177,10 +177,11 @@ def main():
 The `render.star` module also provides `canvas`, which lets an app
 fetch information about the current output configuration.
 
-| Function   | Description                      |
-|------------|----------------------------------|
-| `width()`  | Returns the canvas width in px.  |
-| `height()` | Returns the canvas height in px. |
+| Function       | Description                                                            |
+|----------------|------------------------------------------------------------------------|
+| `width(raw?)`  | Returns the device width in px. Pass `raw` to get the unscaled value.  |
+| `height(raw?)` | Returns the canvas height in px. Pass `raw` to get the unscaled value. |
+| `is2x()`       | Returns true if the device renders at 2x resolution.                   |
 
 ```starlark
 load("render.star", "render", "canvas")

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -344,6 +344,7 @@ displaying stale data in the event of e.g. connectivity issues.
 | `delay` | `int` | Frame delay in milliseconds | N |
 | `max_age` | `int` | Expiration time in seconds | N |
 | `show_full_animation` | `bool` | Request animation is shown in full, regardless of app cycle speed | N |
+| `supports_2x` | `bool` | Indicates that an app supports 2x resolution (if false, 2x displays will show a magnified output) | N |
 
 
 ## Row

--- a/encode/filter.go
+++ b/encode/filter.go
@@ -12,6 +12,7 @@ import (
 type RenderFilters struct {
 	Magnify     int             `json:"magnify,omitempty"`
 	ColorFilter ColorFilterType `json:"color_filter,omitempty"`
+	Output2x    bool            `json:"2x,omitempty"`
 }
 
 type ColorFilterType string

--- a/library/library.go
+++ b/library/library.go
@@ -35,7 +35,7 @@ import (
 //   - timeout (C.int): The timeout (in milliseconds) for rendering.
 //   - imageFormat (C.int): The format of the rendered image (e.g., PNG, GIF).
 //   - silenceOutput (C.int): A flag to suppress output (non-zero to silence).
-//   - filtersPtr (*C.char): A JSON string for optional filters (e.g. {"magnify":2,"color_filter":"warm"})
+//   - filtersPtr (*C.char): A JSON string for optional filters (e.g. {"magnify":2,"color_filter":"warm","2x":true})
 //
 // Returns:
 //   - (*C.uchar): A pointer to the rendered image bytes.

--- a/render/root.go
+++ b/render/root.go
@@ -38,11 +38,13 @@ const (
 // DOC(Delay): Frame delay in milliseconds
 // DOC(MaxAge): Expiration time in seconds
 // DOC(ShowFullAnimation): Request animation is shown in full, regardless of app cycle speed
+// DOC(Supports2x): Indicates that an app supports 2x resolution (if false, 2x displays will show a magnified output)
 type Root struct {
 	Child             Widget `starlark:"child,required"`
 	Delay             int32  `starlark:"delay"`
 	MaxAge            int32  `starlark:"max_age"`
 	ShowFullAnimation bool   `starlark:"show_full_animation"`
+	Supports2x        bool   `starlark:"supports_2x"`
 
 	maxParallelFrames int
 	maxFrameCount     int

--- a/runtime/gen/header/render.tmpl
+++ b/runtime/gen/header/render.tmpl
@@ -51,6 +51,7 @@ func LoadRenderModule() (starlark.StringDict, error) {
 				Members: starlark.StringDict{
 					"width":  starlark.NewBuiltin("width", dimension(dimensionWidth)),
 					"height": starlark.NewBuiltin("height", dimension(dimensionHeight)),
+					"is2x":   starlark.NewBuiltin("is2x", is2x),
 				},
 			},
 		}

--- a/runtime/modules/render_runtime/generated.go
+++ b/runtime/modules/render_runtime/generated.go
@@ -79,6 +79,7 @@ func LoadRenderModule() (starlark.StringDict, error) {
 				Members: starlark.StringDict{
 					"width":  starlark.NewBuiltin("width", dimension(dimensionWidth)),
 					"height": starlark.NewBuiltin("height", dimension(dimensionHeight)),
+					"is2x":   starlark.NewBuiltin("is2x", is2x),
 				},
 			},
 		}
@@ -1828,6 +1829,7 @@ func newRoot(
 		delay               starlark.Int
 		max_age             starlark.Int
 		show_full_animation starlark.Bool
+		supports_2x         starlark.Bool
 	)
 
 	if err := starlark.UnpackArgs(
@@ -1837,6 +1839,7 @@ func newRoot(
 		"delay?", &delay,
 		"max_age?", &max_age,
 		"show_full_animation?", &show_full_animation,
+		"supports_2x?", &supports_2x,
 	); err != nil {
 		return nil, fmt.Errorf("unpacking arguments for Root: %s", err)
 	}
@@ -1869,6 +1872,8 @@ func newRoot(
 
 	w.ShowFullAnimation = bool(show_full_animation)
 
+	w.Supports2x = bool(supports_2x)
+
 	return w, nil
 }
 
@@ -1878,7 +1883,7 @@ func (w *Root) AsRenderRoot() render.Root {
 
 func (w *Root) AttrNames() []string {
 	return []string{
-		"child", "delay", "max_age", "show_full_animation",
+		"child", "delay", "max_age", "show_full_animation", "supports_2x",
 	}
 }
 
@@ -1900,6 +1905,10 @@ func (w *Root) Attr(name string) (starlark.Value, error) {
 	case "show_full_animation":
 
 		return starlark.Bool(w.ShowFullAnimation), nil
+
+	case "supports_2x":
+
+		return starlark.Bool(w.Supports2x), nil
 
 	default:
 		return nil, nil

--- a/runtime/modules/render_runtime/metadata.go
+++ b/runtime/modules/render_runtime/metadata.go
@@ -7,15 +7,30 @@ import (
 	"go.starlark.net/starlark"
 )
 
-type Metadata struct {
-	Width  int
-	Height int
-}
-
 const threadMetadataKey = "tidbyt.dev/pixlet/runtime/$metadata"
 
 func AttachToThread(t *starlark.Thread, m Metadata) {
 	t.SetLocal(threadMetadataKey, m)
+}
+
+type Metadata struct {
+	Width  int
+	Height int
+	Is2x   bool
+}
+
+func (m Metadata) ScaledWidth() int {
+	if m.Is2x {
+		return m.Width * 2
+	}
+	return m.Width
+}
+
+func (m Metadata) ScaledHeight() int {
+	if m.Is2x {
+		return m.Height * 2
+	}
+	return m.Height
 }
 
 type dimensionType uint8
@@ -37,16 +52,43 @@ func dimension(d dimensionType) func(*starlark.Thread, *starlark.Builtin, starla
 			return nil, ErrNoMetadata
 		}
 
+		var raw bool
+
+		if err := starlark.UnpackArgs(
+			string(d),
+			args, kwargs,
+			"raw?", &raw,
+		); err != nil {
+			return nil, fmt.Errorf("unpacking arguments for %s: %w", string(d), err)
+		}
+
 		var val int
 		switch d {
 		case dimensionWidth:
-			val = m.Width
+			if raw {
+				val = m.Width
+			} else {
+				val = m.ScaledWidth()
+			}
 		case dimensionHeight:
-			val = m.Height
+			if raw {
+				val = m.Height
+			} else {
+				val = m.ScaledHeight()
+			}
 		default:
 			return nil, fmt.Errorf("%w: %d", ErrUnknownDimension, d)
 		}
 
 		return starlark.MakeInt(val), nil
 	}
+}
+
+func is2x(thread *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+	m, ok := thread.Local(threadMetadataKey).(Metadata)
+	if !ok {
+		return nil, ErrNoMetadata
+	}
+
+	return starlark.Bool(m.Is2x), nil
 }


### PR DESCRIPTION
The current 2x rendering workflow is clunky. To render an app at 2x, you must manually set both dimensions and pass a variable:
```
pixlet render example.star --width 128 --height 64 '$2x=true'
```
The `supports2x` flag in the manifest feels too decoupled. 2x support should be determined by app logic, not metadata.

## Summary
This PR adds native 2x rendering support via CLI, API, and library options. Pixlet now automatically detects `supports_2x = True` in apps and adjusts dimensions or magnifies output accordingly.

After this PR, the previous command would be simplified to:
```
pixlet render example.star --2x
```

## Details
This PR adds native support for 2x rendering.
1. The `pixlet render` command has a new `--2x` (`-2`) flag
2. The API has a new `2x` JSON field
3. To avoid a breaking change, the library interface accepts the 2x parameter in the `filtersPtr` parameter JSON as `2x`

When any of these are set to `true`, the renderer will check whether the app supports 2x. If it does, Pixlet doubles the canvas dimensions so the app can render at full resolution. Otherwise, Pixlet magnifies the output.

## Examples

### App Without 2x Support

The following `hello_world.star` does not explicitly support 2x, so it is magnified.

```python
load("render.star", "render")

def main():
    return render.Root(
        child = render.Text("Hello, World!"),
    )
```

| `pixlet render hello_world.star` | `pixlet render hello_world.star --2x` |
|----|----|
| ![hello_world 1x](https://github.com/user-attachments/assets/31745e54-9340-4276-8663-1ccbd0374584) | ![hello_world 2x](https://github.com/user-attachments/assets/33ef1fa3-3647-4c5c-b3e4-4eb2deee81b8) |

### App With 2x Support

The following `hello_world.star` supports 2x. Instead of being magnified, the output dimensions are doubled so that the app can position and resize elements accordingly.

```python
load("render.star", "render")

def main():
    return render.Root(
        supports_2x = True,
        child = render.Text("Hello, World!"),
    )
```

| `pixlet render hello_world.star` | `pixlet render hello_world.star --2x` |
|----|----|
| ![hello_world 1x](https://github.com/user-attachments/assets/31745e54-9340-4276-8663-1ccbd0374584) | ![hello_world](https://github.com/user-attachments/assets/b2bb83fa-852f-48de-8c67-6c16671198b6) |

## Compatibility Notes

1. Apps using `supports_2x = True` will not work with an older Pixlet version. Older versions will fail with:
  ```
  Error in Root: unpacking arguments for Root: Root: unexpected keyword argument "supports_2x"
  ```
2. Apps that set the old `supports2x` in the manifest but don't set `supports_2x = True` in the star file will still render, but their 2x output will be magnified, potentially cropping content.

## Result

This simplifies Pixlet 2x rendering, removes reliance on a `manifest.yaml`, gives apps more control over their output, and will allow for [this code](https://github.com/tronbyt/server/blob/cc5ed7f17d541c4d3b07a5c2357d89fe531eabbe/tronbyt_server/utils.py#L59-L68) in tronbyt/server to be simplified.