### PR TITLE
feat: add list-fonts subcommand

### DIFF
--- a/cmd/community/community.go
+++ b/cmd/community/community.go
@@ -5,6 +5,7 @@ import (
 )
 
 func init() {
+	CommunityCmd.AddCommand(ListFontsCmd)
 	CommunityCmd.AddCommand(ListIconsCmd)
 	CommunityCmd.AddCommand(LoadAppCmd)
 	CommunityCmd.AddCommand(ValidateIconsCmd)

--- a/cmd/community/listfonts.go
+++ b/cmd/community/listfonts.go
@@ -1,0 +1,106 @@
+package community
+
+import (
+	"cmp"
+	"fmt"
+	"log/slog"
+	"math"
+	"slices"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"github.com/zachomedia/go-bdf"
+	"tidbyt.dev/pixlet/fonts"
+)
+
+var ListFontsCmd = &cobra.Command{
+	Use:     "list-fonts",
+	Short:   "List available fonts.",
+	Example: `  pixlet community list-fonts`,
+	Long:    `This command lists all fonts supported by this Pixlet version.`,
+	RunE:    listFonts,
+}
+
+type fontEntry struct {
+	name       string
+	advanceMin int
+	advanceMax int
+	height     int
+	ascent     int
+	descent    int
+}
+
+func listFonts(cmd *cobra.Command, _ []string) error {
+	dir, err := fonts.FS.ReadDir(".")
+	if err != nil {
+		return fmt.Errorf("could not read fonts: %w", err)
+	}
+
+	entries := make([]fontEntry, 0, len(dir))
+	for _, entry := range dir {
+		if strings.HasSuffix(entry.Name(), fonts.Ext) {
+			name := strings.TrimSuffix(entry.Name(), fonts.Ext)
+
+			b, err := fonts.GetBytes(name)
+			if err != nil {
+				slog.Error("could not read font", "name", name, "err", err)
+				continue
+			}
+
+			f, err := bdf.Parse(b)
+			if err != nil {
+				slog.Error("could not parse font", "name", name, "err", err)
+				continue
+			}
+
+			var advanceMin, advanceMax int
+			if len(f.Characters) != 0 {
+				advanceMin = math.MaxInt
+				advanceMax = math.MinInt
+				for _, c := range f.Characters {
+					advanceMin = min(c.Advance[0], advanceMin)
+					advanceMax = max(c.Advance[0], advanceMax)
+				}
+			}
+
+			entries = append(entries, fontEntry{
+				name:       name,
+				advanceMin: advanceMin,
+				advanceMax: advanceMax,
+				height:     f.Ascent + f.Descent,
+				ascent:     f.Ascent,
+				descent:    f.Descent,
+			})
+		}
+	}
+
+	slices.SortFunc(entries, func(a, b fontEntry) int {
+		return cmp.Or(
+			cmp.Compare(a.height, b.height),
+			cmp.Compare(a.name, b.name),
+		)
+	})
+
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 3, ' ', 0)
+	if _, err := w.Write([]byte("NAME\tADVANCE\tHEIGHT\tASCENT\tDESCENT\n")); err != nil {
+		return err
+	}
+
+	for _, e := range entries {
+		advance := strconv.Itoa(e.advanceMin)
+		if e.advanceMin != e.advanceMax {
+			advance += "-" + strconv.Itoa(e.advanceMax)
+		}
+
+		if _, err := fmt.Fprintf(
+			w, "%s\t%s\t%d\t%d\t%d\n",
+			e.name, advance, e.height, e.ascent, e.descent,
+		); err != nil {
+			return err
+		}
+	}
+
+	return w.Flush()
+}


### PR DESCRIPTION
Adds a new subcommand `pixlet community list-fonts`. Supported font names are printed along with some metadata for each font. Output is sorted by height, then by name.
```
❯ pixlet community list-fonts
NAME                ADVANCE   HEIGHT   ASCENT   DESCENT
CG-pixel-3x5-mono   1-4       5        5        0
CG-pixel-4x5-mono   2-5       5        5        0
tom-thumb           4-6       6        5        1
5x8                 5         8        7        1
tb-8                2-6       8        7        1
6x10                6         10       8        2
6x10-rounded        6         10       8        2
Dina_r400-6         6         10       8        2
terminus-12         2-7       12       10       2
terminus-12-light   6         12       10       2
6x13                6         13       11       2
terminus-14         3-10      14       12       2
terminus-14-light   3-10      14       12       2
terminus-16         3-10      16       12       4
terminus-16-light   3-10      16       12       4
terminus-18         3-12      18       15       3
terminus-18-light   3-12      18       15       3
10x20               10        20       16       4
terminus-20         3-12      20       16       4
terminus-20-light   3-12      20       16       4
terminus-22         3-13      22       17       5
terminus-22-light   3-13      22       17       5
terminus-24         4-14      24       19       5
terminus-24-light   3-14      24       19       5
terminus-28         4-16      28       22       6
terminus-28-light   4-16      28       22       6
terminus-32         4-18      32       26       6
terminus-32-light   4-18      32       26       6
```