### PR TITLE
feat(render): add canvas width/height helpers

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -172,6 +172,29 @@ def main():
     return r.Root(child=r.Box(width=12, height=14, color="#ff0"))
 ```
 
+### Canvas
+
+The `render.star` module also provides `canvas`, which lets an app
+fetch information about the current output configuration.
+
+| Function   | Description                      |
+|------------|----------------------------------|
+| `width()`  | Returns the canvas width in px.  |
+| `height()` | Returns the canvas height in px. |
+
+```starlark
+load("render.star", "render", "canvas")
+
+def main(config):
+    w, h = canvas.width(), canvas.height()
+    return render.Root(
+        child = render.Padding(
+            child = render.Text("%dx%d" % (w, h)),
+            pad = 1,
+        ),
+    )
+```
+
 ## Pixlet module: Schema
 
 The schema module provides configuration options for your app. See the [schema documentation](schema/schema.md) for more details.

--- a/runtime/applet.go
+++ b/runtime/applet.go
@@ -112,6 +112,16 @@ func WithPrintDisabled() AppletOption {
 	return WithPrintFunc(func(thread *starlark.Thread, msg string) {})
 }
 
+func WithMetadata(m render_runtime.Metadata) AppletOption {
+	return func(a *Applet) error {
+		a.initializers = append(a.initializers, func(t *starlark.Thread) *starlark.Thread {
+			render_runtime.AttachToThread(t, m)
+			return t
+		})
+		return nil
+	}
+}
+
 func NewApplet(id string, src []byte, opts ...AppletOption) (*Applet, error) {
 	fn := id
 	if !strings.HasSuffix(fn, ".star") {

--- a/runtime/gen/header/render.tmpl
+++ b/runtime/gen/header/render.tmpl
@@ -46,6 +46,13 @@ func LoadRenderModule() (starlark.StringDict, error) {
 {{end}}
 				},
 			},
+			"canvas": &starlarkstruct.Module{
+				Name: "canvas",
+				Members: starlark.StringDict{
+					"width":  starlark.NewBuiltin("width", dimension(dimensionWidth)),
+					"height": starlark.NewBuiltin("height", dimension(dimensionHeight)),
+				},
+			},
 		}
 	})
 

--- a/runtime/modules/render_runtime/generated.go
+++ b/runtime/modules/render_runtime/generated.go
@@ -74,6 +74,13 @@ func LoadRenderModule() (starlark.StringDict, error) {
 					"WrappedText": starlark.NewBuiltin("WrappedText", newWrappedText),
 				},
 			},
+			"canvas": &starlarkstruct.Module{
+				Name: "canvas",
+				Members: starlark.StringDict{
+					"width":  starlark.NewBuiltin("width", dimension(dimensionWidth)),
+					"height": starlark.NewBuiltin("height", dimension(dimensionHeight)),
+				},
+			},
 		}
 	})
 

--- a/runtime/modules/render_runtime/metadata.go
+++ b/runtime/modules/render_runtime/metadata.go
@@ -1,0 +1,52 @@
+package render_runtime
+
+import (
+	"errors"
+	"fmt"
+
+	"go.starlark.net/starlark"
+)
+
+type Metadata struct {
+	Width  int
+	Height int
+}
+
+const threadMetadataKey = "tidbyt.dev/pixlet/runtime/$metadata"
+
+func AttachToThread(t *starlark.Thread, m Metadata) {
+	t.SetLocal(threadMetadataKey, m)
+}
+
+type dimensionType uint8
+
+const (
+	dimensionWidth dimensionType = iota
+	dimensionHeight
+)
+
+var (
+	ErrUnknownDimension = errors.New("unknown dimension")
+	ErrNoMetadata       = errors.New("no metadata available")
+)
+
+func dimension(d dimensionType) func(*starlark.Thread, *starlark.Builtin, starlark.Tuple, []starlark.Tuple) (starlark.Value, error) {
+	return func(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		m, ok := thread.Local(threadMetadataKey).(Metadata)
+		if !ok {
+			return nil, ErrNoMetadata
+		}
+
+		var val int
+		switch d {
+		case dimensionWidth:
+			val = m.Width
+		case dimensionHeight:
+			val = m.Height
+		default:
+			return nil, fmt.Errorf("%w: %d", ErrUnknownDimension, d)
+		}
+
+		return starlark.MakeInt(val), nil
+	}
+}

--- a/server/loader/loader.go
+++ b/server/loader/loader.go
@@ -17,6 +17,7 @@ import (
 	"go.starlark.net/starlark"
 	"tidbyt.dev/pixlet/encode"
 	"tidbyt.dev/pixlet/runtime"
+	"tidbyt.dev/pixlet/runtime/modules/render_runtime"
 	"tidbyt.dev/pixlet/schema"
 	"tidbyt.dev/pixlet/tools"
 )
@@ -285,11 +286,16 @@ func RenderApplet(path string, config map[string]string, width, height, magnify,
 		fs = tools.NewSingleFileFS(path)
 	}
 
-	// Replace the print function from the starlark thread if the silent flag is
-	// passed.
-	var opts []runtime.AppletOption
+	opts := []runtime.AppletOption{
+		runtime.WithMetadata(render_runtime.Metadata{
+			Width:  width,
+			Height: height,
+		}),
+	}
+
 	var output []string
 	if silenceOutput {
+		// Replace the print function from the starlark thread if the silent flag is passed.
 		opts = append(opts, runtime.WithPrintFunc(func(thread *starlark.Thread, msg string) {
 			output = append(output, msg)
 		}))


### PR DESCRIPTION
Adds a new `canvas` variable to `render.star`. The `canvas` var has helpers `canvas.width()` and `canvas.height()`.

Example:
```starlark
load("render.star", "render", "canvas")

def main(config):
    w, h = canvas.width(), canvas.height()
    return render.Root(
        child = render.Padding(
            child = render.Text("%dx%d" % (w, h)),
            pad = 1,
        ),
    )
```