### PR TITLE
fix: file does not exist error when a multiple star files exist

### DIFF
--- a/runtime/applet.go
+++ b/runtime/applet.go
@@ -347,14 +347,20 @@ func (a *Applet) load(fsys fs.FS) (err error) {
 		return fmt.Errorf("reading root directory: %v", err)
 	}
 
-	for _, d := range rootDir {
-		if d.IsDir() || !strings.HasSuffix(d.Name(), ".star") {
-			// only process Starlark files
-			continue
-		}
-
-		if err := a.ensureLoaded(fsys, d.Name()); err != nil {
+	if path.Ext(a.ID) == ".star" {
+		if err := a.ensureLoaded(fsys, a.ID); err != nil {
 			return err
+		}
+	} else {
+		for _, d := range rootDir {
+			if d.IsDir() || !strings.HasSuffix(d.Name(), ".star") {
+				// only process Starlark files
+				continue
+			}
+
+			if err := a.ensureLoaded(fsys, d.Name()); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
Currently, if multiple star files exist in a directory and Pixlet attempts to load one, it results in a confusing `file does not exist` error for one of the other star files. This PR makes it only load the provided star file, fixing this error. If a directory is passed, behavior is unchanged.

This is not a breaking change since [`tools.SingleFileFS`](https://github.com/tronbyt/pixlet/blob/d31b6ea417470be320315d266a8a8211924ff051/tools/singlefilefs.go#L9-L27) only allows the star file to be loaded anyways.