### PR TITLE
chore: clean up app loading logic

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -12,7 +12,6 @@ import (
 	"github.com/spf13/cobra"
 	"tidbyt.dev/pixlet/cmd/community"
 	"tidbyt.dev/pixlet/manifest"
-	"tidbyt.dev/pixlet/tools"
 )
 
 var maxRenderTime = time.Duration(1 * time.Second)
@@ -50,19 +49,15 @@ func checkCmd(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("failed to stat %s: %w", path, err)
 		}
 
-		var fsys fs.FS
-		var baseDir string
-		if info.IsDir() {
-			fsys = os.DirFS(path)
-			baseDir = path
-		} else {
+		baseDir := path
+		if !info.IsDir() {
 			if !strings.HasSuffix(path, ".star") {
 				return fmt.Errorf("script file must have suffix .star: %s", path)
 			}
-
-			fsys = tools.NewSingleFileFS(path)
 			baseDir = filepath.Dir(path)
 		}
+
+		fsys := os.DirFS(baseDir)
 
 		// Check if an app can load.
 		err = community.LoadApp(cmd, []string{path})

--- a/cmd/community/loadapp.go
+++ b/cmd/community/loadapp.go
@@ -2,14 +2,9 @@ package community
 
 import (
 	"fmt"
-	"io/fs"
-	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"tidbyt.dev/pixlet/runtime"
-	"tidbyt.dev/pixlet/tools"
 )
 
 var LoadAppCmd = &cobra.Command{
@@ -24,28 +19,11 @@ var LoadAppCmd = &cobra.Command{
 func LoadApp(cmd *cobra.Command, args []string) error {
 	path := args[0]
 
-	// check if path exists, and whether it is a directory or a file
-	info, err := os.Stat(path)
-	if err != nil {
-		return fmt.Errorf("failed to stat %s: %w", path, err)
-	}
-
-	var fs fs.FS
-	if info.IsDir() {
-		fs = os.DirFS(path)
-	} else {
-		if !strings.HasSuffix(path, ".star") {
-			return fmt.Errorf("script file must have suffix .star: %s", path)
-		}
-
-		fs = tools.NewSingleFileFS(path)
-	}
-
 	cache := runtime.NewInMemoryCache()
 	runtime.InitHTTP(cache)
 	runtime.InitCache(cache)
 
-	if _, err := runtime.NewAppletFromFS(filepath.Base(path), fs, runtime.WithPrintDisabled()); err != nil {
+	if _, err := runtime.NewAppletFromPath(path, runtime.WithPrintDisabled()); err != nil {
 		return fmt.Errorf("failed to load applet: %w", err)
 	}
 

--- a/cmd/community/validateicons.go
+++ b/cmd/community/validateicons.go
@@ -3,17 +3,12 @@ package community
 import (
 	"encoding/json"
 	"fmt"
-	"io/fs"
-	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/spf13/cobra"
 
 	"tidbyt.dev/pixlet/icons"
 	"tidbyt.dev/pixlet/runtime"
 	"tidbyt.dev/pixlet/schema"
-	"tidbyt.dev/pixlet/tools"
 )
 
 var ValidateIconsCmd = &cobra.Command{
@@ -29,28 +24,11 @@ by our mobile app.`,
 func ValidateIcons(cmd *cobra.Command, args []string) error {
 	path := args[0]
 
-	// check if path exists, and whether it is a directory or a file
-	info, err := os.Stat(path)
-	if err != nil {
-		return fmt.Errorf("failed to stat %s: %w", path, err)
-	}
-
-	var fs fs.FS
-	if info.IsDir() {
-		fs = os.DirFS(path)
-	} else {
-		if !strings.HasSuffix(path, ".star") {
-			return fmt.Errorf("script file must have suffix .star: %s", path)
-		}
-
-		fs = tools.NewSingleFileFS(path)
-	}
-
 	cache := runtime.NewInMemoryCache()
 	runtime.InitHTTP(cache)
 	runtime.InitCache(cache)
 
-	applet, err := runtime.NewAppletFromFS(filepath.Base(path), fs, runtime.WithPrintDisabled())
+	applet, err := runtime.NewAppletFromPath(path, runtime.WithPrintDisabled())
 	if err != nil {
 		return fmt.Errorf("failed to load applet: %w", err)
 	}

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/fs"
 	"os"
 	"strings"
 	"time"
@@ -15,7 +14,6 @@ import (
 	"go.starlark.net/starlark"
 
 	"tidbyt.dev/pixlet/runtime"
-	"tidbyt.dev/pixlet/tools"
 )
 
 var (
@@ -95,27 +93,11 @@ func profile(cmd *cobra.Command, args []string) error {
 }
 
 func ProfileApp(path string, config map[string]string) (*pprof_profile.Profile, error) {
-	info, err := os.Stat(path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to stat %s: %w", path, err)
-	}
-
-	var fsys fs.FS
-	if info.IsDir() {
-		fsys = os.DirFS(path)
-	} else {
-		if !strings.HasSuffix(path, ".star") {
-			return nil, fmt.Errorf("script file must have suffix .star: %s", path)
-		}
-
-		fsys = tools.NewSingleFileFS(path)
-	}
-
 	cache := runtime.NewInMemoryCache()
 	runtime.InitHTTP(cache)
 	runtime.InitCache(cache)
 
-	applet, err := runtime.NewAppletFromFS(path, fsys, runtime.WithPrintDisabled())
+	applet, err := runtime.NewAppletFromPath(path, runtime.WithPrintDisabled())
 	if err != nil {
 		return nil, fmt.Errorf("failed to load applet: %w", err)
 	}

--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -3,14 +3,10 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"io/fs"
 	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"tidbyt.dev/pixlet/runtime"
-	"tidbyt.dev/pixlet/tools"
 )
 
 var (
@@ -38,24 +34,7 @@ JSON format.
 func schema(cmd *cobra.Command, args []string) error {
 	path := args[0]
 
-	// check if path exists, and whether it is a directory or a file
-	info, err := os.Stat(path)
-	if err != nil {
-		return fmt.Errorf("failed to stat %s: %w", path, err)
-	}
-
-	var fs fs.FS
-	if info.IsDir() {
-		fs = os.DirFS(path)
-	} else {
-		if !strings.HasSuffix(path, ".star") {
-			return fmt.Errorf("script file must have suffix .star: %s", path)
-		}
-
-		fs = tools.NewSingleFileFS(path)
-	}
-
-	applet, err := runtime.NewAppletFromFS(filepath.Base(path), fs)
+	applet, err := runtime.NewAppletFromPath(path)
 	if err != nil {
 		return fmt.Errorf("failed to load applet: %w", err)
 	}

--- a/server/loader/loader.go
+++ b/server/loader/loader.go
@@ -10,8 +10,6 @@ import (
 	"io/fs"
 	"log"
 	"os"
-	"path/filepath"
-	"strings"
 	"time"
 
 	"go.starlark.net/starlark"
@@ -19,7 +17,6 @@ import (
 	"tidbyt.dev/pixlet/runtime"
 	"tidbyt.dev/pixlet/runtime/modules/render_runtime"
 	"tidbyt.dev/pixlet/schema"
-	"tidbyt.dev/pixlet/tools"
 )
 
 type ImageFormat int
@@ -269,23 +266,6 @@ func (l *Loader) markInitialLoadComplete() {
 }
 
 func RenderApplet(path string, config map[string]string, width, height, magnify, maxDuration, timeout int, imageFormat ImageFormat, silenceOutput bool, filters *encode.RenderFilters) ([]byte, []string, error) {
-	// check if path exists, and whether it is a directory or a file
-	info, err := os.Stat(path)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to stat %s: %w", path, err)
-	}
-
-	var fs fs.FS
-	if info.IsDir() {
-		fs = os.DirFS(path)
-	} else {
-		if !strings.HasSuffix(path, ".star") {
-			return nil, nil, fmt.Errorf("script file must have suffix .star: %s", path)
-		}
-
-		fs = tools.NewSingleFileFS(path)
-	}
-
 	if filters == nil {
 		filters = &encode.RenderFilters{}
 	}
@@ -320,7 +300,7 @@ func RenderApplet(path string, config map[string]string, width, height, magnify,
 		defer cancel()
 	}
 
-	applet, err := runtime.NewAppletFromFS(filepath.Base(path), fs, opts...)
+	applet, err := runtime.NewAppletFromPath(path, opts...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to load applet: %w", err)
 	}


### PR DESCRIPTION
Moves repeated app loading logic into a single `applet.NewAppletFromPath` func