### PR TITLE
fix(render): `pixlet render .` outputs file at `..webp`

### DIFF
--- a/cmd/render.go
+++ b/cmd/render.go
@@ -154,7 +154,12 @@ func render(cmd *cobra.Command, args []string) error {
 
 	var outPath string
 	if info.IsDir() {
-		outPath = filepath.Join(path, filepath.Base(path))
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			return fmt.Errorf("failed to get absolute path for %s: %w", path, err)
+		}
+
+		outPath = filepath.Join(path, filepath.Base(abs))
 	} else {
 		if !strings.HasSuffix(path, ".star") {
 			return fmt.Errorf("script file must have suffix .star: %s", path)


### PR DESCRIPTION
If you run `pixlet render .`, it will generate `..webp`. This PR properly resolves the app name even when the provided path ends with `.` or `..`.