### PR TITLE
Revert "fix: pin buildifier version"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ release-windows: clean
 	./scripts/release-windows.sh
 
 install-buildifier:
-	$(GO_CMD) install github.com/bazelbuild/buildtools/buildifier@v0.0.0-20251107112229-e879524f2986
+	$(GO_CMD) install github.com/bazelbuild/buildtools/buildifier@latest
 
 lint:
 	@ buildifier --version >/dev/null 2>&1 || $(MAKE) install-buildifier


### PR DESCRIPTION
Reverts tronbyt/pixlet#250

The upstream commit was reverted by https://github.com/bazelbuild/buildtools/pull/1413