### PR TITLE
fix: fix `pixlet profile` (and transitively `pixlet check`)

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -110,7 +110,7 @@ func checkCmd(cmd *cobra.Command, args []string) error {
 		}
 
 		// Check performance.
-		p, err := ProfileApp(path, map[string]string{})
+		p, err := ProfileApp(path, map[string]string{}, 64, 32, false)
 		if err != nil {
 			return fmt.Errorf("could not profile app: %w", err)
 		}


### PR DESCRIPTION
Add runtime.Metadata to the profile command to fix the following error for apps using `canvas.is2x()`:

```
❯ pixlet check apps/fuzzyclock/fuzzy_clock.star
Error: could not profile app: error running script: Traceback (most recent call last):
  fuzzy_clock.star/fuzzy_clock.star:299:29: in main
Error in is2x: no metadata available
```

This change also allow profiling with different device characteristics.