### PR TITLE
chore(fonts): remove gz files before gzipping fonts

### DIFF
--- a/fonts/gen/gzip.go
+++ b/fonts/gen/gzip.go
@@ -1,0 +1,71 @@
+//go:build generate
+
+package main
+
+import (
+	"compress/gzip"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+func main() {
+	root, err := os.OpenRoot(".")
+	if err != nil {
+		panic(err)
+	}
+	defer root.Close()
+
+	d, err := fs.ReadDir(root.FS(), ".")
+	if err != nil {
+		panic(err)
+	}
+
+	for _, f := range d {
+		if !f.IsDir() && filepath.Ext(f.Name()) == ".gz" {
+			if err := root.Remove(f.Name()); err != nil {
+				panic(err)
+			}
+		}
+	}
+
+	d, err = fs.ReadDir(root.FS(), ".")
+	if err != nil {
+		panic(err)
+	}
+
+	for _, f := range d {
+		if !f.IsDir() && filepath.Ext(f.Name()) == ".bdf" {
+			if err := compress(root, f.Name()); err != nil {
+				panic(err)
+			}
+		}
+	}
+}
+
+func compress(root *os.Root, path string) error {
+	in, err := root.Open(path)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := root.Create(path + ".gz")
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	gzw := gzip.NewWriter(out)
+
+	if _, err := io.Copy(gzw, in); err != nil {
+		return err
+	}
+
+	if err := gzw.Close(); err != nil {
+		return err
+	}
+
+	return out.Close()
+}

--- a/fonts/generate.go
+++ b/fonts/generate.go
@@ -1,3 +1,3 @@
 package fonts
 
-//go:generate sh -c "rm -f *.bdf.gz && gzip -nkf *.bdf"
+//go:generate go run ./gen/gzip.go


### PR DESCRIPTION
Small change to clean up generated `.bdf.gz` files to ensure the `gzip_fonts` build tag always results in the same output.