### PR TITLE
fix(runtime): enforce app filesystem sandbox

### DIFF
--- a/cmd/community/loadapp.go
+++ b/cmd/community/loadapp.go
@@ -23,9 +23,11 @@ func LoadApp(cmd *cobra.Command, args []string) error {
 	runtime.InitHTTP(cache)
 	runtime.InitCache(cache)
 
-	if _, err := runtime.NewAppletFromPath(path, runtime.WithPrintDisabled()); err != nil {
+	app, err := runtime.NewAppletFromPath(path, runtime.WithPrintDisabled())
+	if err != nil {
 		return fmt.Errorf("failed to load applet: %w", err)
 	}
+	defer app.Close()
 
 	return nil
 }

--- a/cmd/community/validateicons.go
+++ b/cmd/community/validateicons.go
@@ -32,6 +32,7 @@ func ValidateIcons(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to load applet: %w", err)
 	}
+	defer applet.Close()
 
 	s := schema.Schema{}
 	js := applet.SchemaJSON

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -134,6 +134,7 @@ func ProfileApp(path string, config map[string]string, width int, height int, is
 	if err != nil {
 		return nil, fmt.Errorf("failed to load applet: %w", err)
 	}
+	defer applet.Close()
 
 	buf := new(bytes.Buffer)
 	if err = starlark.StartProfile(buf); err != nil {

--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -38,6 +38,7 @@ func schema(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to load applet: %w", err)
 	}
+	defer applet.Close()
 
 	if schemaOutput == "" || schemaOutput == "-" {
 		buf, err := json.MarshalIndent(applet.Schema, "", "  ")

--- a/library/library.go
+++ b/library/library.go
@@ -92,6 +92,7 @@ func get_schema(pathPtr *C.char) (*C.char, C.int) {
 		status := errorStatus(err)
 		return nil, C.int(status)
 	}
+	defer applet.Close()
 
 	return (*C.char)(C.CString(string(applet.SchemaJSON))), 0
 }
@@ -119,6 +120,7 @@ func call_handler_with_config(pathPtr, configPtr *C.char, handlerName, parameter
 		status := errorStatus(err)
 		return nil, C.int(status), C.CString(fmt.Sprintf("error parsing config: %v", err))
 	}
+	defer applet.Close()
 
 	result, err := applet.CallSchemaHandler(context.Background(), C.GoString(handlerName), C.GoString(parameter), config)
 	if err != nil {

--- a/runtime/applet_test.go
+++ b/runtime/applet_test.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 	"testing/fstest"
 
@@ -451,6 +453,24 @@ def main():
 	app, err := NewAppletFromFS("test_read_file", vfs)
 	require.NoError(t, err)
 	app.RunTests(t)
+}
+
+func TestRoot(t *testing.T) {
+	const name = "test_root.star"
+
+	appDir := t.TempDir()
+	otherDir := t.TempDir()
+
+	f, err := os.CreateTemp(otherDir, name)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	err = os.Symlink(f.Name(), filepath.Join(appDir, name))
+	require.NoError(t, err)
+
+	app, err := NewAppletFromPath(appDir)
+	assert.Error(t, err)
+	require.Nil(t, app)
 }
 
 // TODO: test Screens, especially Screens.Render()


### PR DESCRIPTION
Migrates `os.DirFS` calls to `os.OpenRoot`, which prevents breaking out of an app's directory. Filesystem access is currently pretty limited, but this will be more important once #259 is implemented.

For example, this will disallow any attempt to symlink an app:
```
❯ mv examples/hello_world/hello_world.star .
❯ ln -s "$PWD/hello_world.star" examples/hello_world/hello_world.star
❯ pixlet render examples/hello_world
Error: error rendering: failed to load applet: reading hello_world.star: openat hello_world.star: path escapes from parent
```