### PR TITLE
feat(runtime): add module `encoding/yaml.star`

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -302,3 +302,24 @@ def main(config):
         ),
     )
 ```
+
+## Pixlet module: YAML
+
+The `yaml` module provides functions to decode and encode YAML.
+
+| Function             | Description                                                                       |
+|----------------------|-----------------------------------------------------------------------------------|
+| `decode(x)`          | Decodes a YAML-formatted string.                                                  |
+| `encode(x, indent?)` | Encodes a value to a YAML-formatted string. The indent parameter defaults to `2`. |
+
+Example:
+```starlark
+load("encoding/yaml.star", "yaml")
+load("render.star", "render")
+
+EXAMPLE_YAML = "message: Hello, world!"
+
+def main(config):
+    data = yaml.decode(EXAMPLE_YAML)
+    return render.Root(render.Text(data["message"]))
+```

--- a/runtime/applet.go
+++ b/runtime/applet.go
@@ -23,6 +23,7 @@ import (
 	starlibre "github.com/qri-io/starlib/re"
 	starlibzip "github.com/qri-io/starlib/zipfile"
 	"github.com/tronbyt/pixlet/manifest"
+	"github.com/tronbyt/pixlet/runtime/modules/encoding/yaml"
 	starlibjson "go.starlark.net/lib/json"
 	starlibmath "go.starlark.net/lib/math"
 	starlibtime "go.starlark.net/lib/time"
@@ -650,6 +651,9 @@ func (a *Applet) loadModule(thread *starlark.Thread, module string) (starlark.St
 		return starlark.StringDict{
 			starlibjson.Module.Name: starlibjson.Module,
 		}, nil
+
+	case yaml.ModuleName:
+		return yaml.LoadModule()
 
 	case "hash.star":
 		return starlibhash.LoadModule()

--- a/runtime/modules/encoding/yaml/yaml.go
+++ b/runtime/modules/encoding/yaml/yaml.go
@@ -1,0 +1,98 @@
+package yaml
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/qri-io/starlib/util"
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	ModuleName    = "encoding/yaml.star"
+	DefaultIndent = 2
+)
+
+var (
+	once       sync.Once
+	yamlModule starlark.StringDict
+)
+
+// LoadModule loads the yaml module.
+// It is concurrency-safe and idempotent.
+func LoadModule() (starlark.StringDict, error) {
+	once.Do(func() {
+		yamlModule = starlark.StringDict{
+			"yaml": &starlarkstruct.Module{
+				Name: "yaml",
+				Members: starlark.StringDict{
+					"decode": starlark.NewBuiltin("decode", Decode),
+					"encode": starlark.NewBuiltin("encode", Encode),
+				},
+			},
+		}
+	})
+	return yamlModule, nil
+}
+
+// Decode reads the YAML-encoded value from its input and returns the result as a starlark.Value.
+func Decode(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var x starlark.String
+
+	err := starlark.UnpackArgs(
+		"decode", args, kwargs,
+		"x", &x,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	r := strings.NewReader(x.GoString())
+
+	var val any
+	if err := yaml.NewDecoder(r).Decode(&val); err != nil {
+		return starlark.None, err
+	}
+
+	return util.Marshal(val)
+}
+
+// Encode returns the YAML encoding of its input.
+func Encode(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var (
+		x      starlark.Value
+		indent starlark.Int
+	)
+
+	err := starlark.UnpackArgs(
+		"encode", args, kwargs,
+		"x", &x,
+		"indent?", &indent,
+	)
+	if err != nil {
+		return starlark.None, err
+	}
+
+	val, err := util.Unmarshal(x)
+	if err != nil {
+		return starlark.None, err
+	}
+
+	var buf strings.Builder
+	enc := yaml.NewEncoder(&buf)
+	defer enc.Close()
+
+	indentVal := DefaultIndent
+	if v, ok := indent.Int64(); ok && v != 0 {
+		indentVal = int(v)
+	}
+	enc.SetIndent(indentVal)
+
+	if err := enc.Encode(val); err != nil {
+		return starlark.None, err
+	}
+
+	return starlark.String(buf.String()), nil
+}


### PR DESCRIPTION
Adds a new module for YAML decoding and encoding. Documentation at [`encoding/yaml.star`](https://github.com/qri-io/starlib/tree/master/encoding/yaml)