### PR TITLE
feat(render): change default 2x font to `terminus-16`

### DIFF
--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -11,10 +11,10 @@ import (
 	pprof_driver "github.com/google/pprof/driver"
 	pprof_profile "github.com/google/pprof/profile"
 	"github.com/spf13/cobra"
+	"github.com/tronbyt/pixlet/runtime/modules/render_runtime/metadata"
 	"go.starlark.net/starlark"
 
 	"github.com/tronbyt/pixlet/runtime"
-	"github.com/tronbyt/pixlet/runtime/modules/render_runtime"
 )
 
 var (
@@ -125,7 +125,7 @@ func ProfileApp(path string, config map[string]string, width int, height int, is
 	applet, err := runtime.NewAppletFromPath(
 		path,
 		runtime.WithPrintDisabled(),
-		runtime.WithMetadata(render_runtime.Metadata{
+		runtime.WithMetadata(metadata.Metadata{
 			Width:  width,
 			Height: height,
 			Is2x:   is2x,

--- a/render/animation/transformation.go
+++ b/render/animation/transformation.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	"github.com/tronbyt/gg"
+	"go.starlark.net/starlark"
 
 	"github.com/tronbyt/pixlet/render"
 )
@@ -177,7 +178,7 @@ type Transformation struct {
 	WaitForChild bool          `starlark:"wait_for_child"`
 }
 
-func (self *Transformation) Init() error {
+func (self *Transformation) Init(*starlark.Thread) error {
 	self.Keyframes = processKeyframes(self.Keyframes)
 
 	return nil

--- a/render/emoji.go
+++ b/render/emoji.go
@@ -8,6 +8,7 @@ import (
 	"github.com/nfnt/resize"
 	"github.com/tronbyt/gg"
 	"github.com/tronbyt/pixlet/render/emoji"
+	"go.starlark.net/starlark"
 )
 
 // Emoji renders a single emoji at a specified height, maintaining aspect ratio.
@@ -49,7 +50,7 @@ func (e *Emoji) PaintBounds(bounds image.Rectangle, frameIdx int) image.Rectangl
 	return image.Rect(0, 0, e.img.Bounds().Dx(), e.img.Bounds().Dy())
 }
 
-func (e *Emoji) Init() error {
+func (e *Emoji) Init(*starlark.Thread) error {
 	if e.Height < 0 {
 		return fmt.Errorf("emoji height must not be negative, got %d", e.Height)
 	}

--- a/render/emoji_test.go
+++ b/render/emoji_test.go
@@ -102,7 +102,7 @@ func TestEmojiWidget(t *testing.T) {
 				Height:   tt.height,
 			}
 
-			err := emoji.Init()
+			err := emoji.Init(nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Emoji.Init() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -153,7 +153,7 @@ func TestEmojiWidgetSize(t *testing.T) {
 				Height:   tt.height,
 			}
 
-			err := emoji.Init()
+			err := emoji.Init(nil)
 			if err != nil {
 				t.Fatalf("Emoji.Init() failed: %v", err)
 			}
@@ -185,7 +185,7 @@ func TestEmojiWidgetFrameCount(t *testing.T) {
 		Height:   16,
 	}
 
-	err := emoji.Init()
+	err := emoji.Init(nil)
 	if err != nil {
 		t.Fatalf("Emoji.Init() failed: %v", err)
 	}
@@ -217,7 +217,7 @@ func BenchmarkEmojiWidget(b *testing.B) {
 					Height:   tt.height,
 				}
 
-				err := emoji.Init()
+				err := emoji.Init(nil)
 				if err != nil {
 					b.Fatalf("Emoji.Init() failed: %v", err)
 				}

--- a/render/image.go
+++ b/render/image.go
@@ -18,6 +18,7 @@ import (
 	"github.com/srwiley/oksvg"
 	"github.com/srwiley/rasterx"
 	"github.com/tronbyt/gg"
+	"go.starlark.net/starlark"
 )
 
 // Image renders the binary image data passed via `src`. Supported
@@ -158,7 +159,7 @@ func (p *Image) InitFromSVG(data []byte) error {
 	return nil
 }
 
-func (p *Image) Init() error {
+func (p *Image) Init(*starlark.Thread) error {
 	err := p.InitFromWebP([]byte(p.Src))
 	if err != nil {
 		err = p.InitFromGIF([]byte(p.Src))

--- a/render/image_test.go
+++ b/render/image_test.go
@@ -15,7 +15,7 @@ const testPNG = "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAMCAYAAABbayygAAAAOUlEQVQoU2P8z8D
 func TestImage(t *testing.T) {
 	raw, _ := base64.StdEncoding.DecodeString(testPNG)
 	img := &Image{Src: string(raw)}
-	img.Init()
+	img.Init(nil)
 
 	// Size of Image is independent of bounds
 	im := PaintWidget(img, image.Rect(0, 0, 0, 0), 0)
@@ -62,7 +62,7 @@ func TestImage(t *testing.T) {
 func TestImageScale(t *testing.T) {
 	raw, _ := base64.StdEncoding.DecodeString(testPNG)
 	img := &Image{Src: string(raw), Width: 5, Height: 6}
-	img.Init()
+	img.Init(nil)
 
 	w, h := img.Size()
 	assert.Equal(t, 5, w)
@@ -78,7 +78,7 @@ func TestImageScale(t *testing.T) {
 func TestImageScaleAspectRatioWidth(t *testing.T) {
 	raw, _ := base64.StdEncoding.DecodeString(testPNG)
 	img := &Image{Src: string(raw), Width: 5}
-	img.Init()
+	img.Init(nil)
 
 	w, h := img.Size()
 	assert.Equal(t, 5, w)
@@ -94,7 +94,7 @@ func TestImageScaleAspectRatioWidth(t *testing.T) {
 func TestImageScaleAspectRatioHeight(t *testing.T) {
 	raw, _ := base64.StdEncoding.DecodeString(testPNG)
 	img := &Image{Src: string(raw), Height: 6}
-	img.Init()
+	img.Init(nil)
 
 	w, h := img.Size()
 	assert.Equal(t, 5, w)
@@ -121,7 +121,7 @@ func TestImageAnimatedGif(t *testing.T) {
 
 	raw, _ := base64.StdEncoding.DecodeString(testGIF)
 	img := &Image{Src: string(raw)}
-	img.Init()
+	img.Init(nil)
 
 	w, h := img.Size()
 	assert.Equal(t, 5, w)

--- a/render/starfield.go
+++ b/render/starfield.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 
 	"github.com/tronbyt/gg"
+	"go.starlark.net/starlark"
 )
 
 type Starfield struct {
@@ -92,7 +93,7 @@ func DrawLine(dc *gg.Context, x0, y0, x1, y1 int) {
 	}
 }
 
-func (s *Starfield) Init() error {
+func (s *Starfield) Init(*starlark.Thread) error {
 	s.initStars(60)
 	return nil
 }

--- a/render/text.go
+++ b/render/text.go
@@ -6,14 +6,18 @@ import (
 
 	"github.com/tronbyt/gg"
 	"github.com/tronbyt/pixlet/render/emoji"
+	"github.com/tronbyt/pixlet/runtime/modules/render_runtime/metadata"
 	"github.com/tronbyt/pixlet/tools/i18n"
+	"go.starlark.net/starlark"
 )
 
-var (
-	DefaultFontFace  = "tb-8"
-	DefaultFontColor = color.White
-	MaxWidth         = 1000
+const (
+	DefaultFontFace   = "tb-8"
+	DefaultFontFace2x = "terminus-16"
+	MaxWidth          = 1000
 )
+
+var DefaultFontColor = color.White
 
 // Text draws a string of text on a single line.
 //
@@ -55,10 +59,11 @@ func (t *Text) PaintBounds(bounds image.Rectangle, frameIdx int) image.Rectangle
 	return image.Rect(0, 0, t.img.Bounds().Dx(), t.img.Bounds().Dy())
 }
 
-func (t *Text) Init() error {
+func (t *Text) Init(thread *starlark.Thread) error {
 	if t.Font == "" {
-		t.Font = DefaultFontFace
+		t.Font = getDefaultFont(thread)
 	}
+
 	face, err := GetFont(t.Font)
 	if err != nil {
 		return err
@@ -120,4 +125,11 @@ func (t *Text) Init() error {
 
 func (t Text) FrameCount(bounds image.Rectangle) int {
 	return 1
+}
+
+func getDefaultFont(thread *starlark.Thread) string {
+	if m, err := metadata.FromThread(thread); err == nil && m.Is2x {
+		return DefaultFontFace2x
+	}
+	return DefaultFontFace
 }

--- a/render/text_emoji_test.go
+++ b/render/text_emoji_test.go
@@ -55,7 +55,7 @@ func TestTextWidgetWithEmojis(t *testing.T) {
 				Color:   color.White,
 			}
 
-			err := text.Init()
+			err := text.Init(nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Text.Init() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -116,7 +116,7 @@ func TestTextWidgetSize(t *testing.T) {
 				Color:   color.White,
 			}
 
-			err := text.Init()
+			err := text.Init(nil)
 			if err != nil {
 				t.Fatalf("Text.Init() failed: %v", err)
 			}
@@ -145,7 +145,7 @@ func TestTextWidgetPaint(t *testing.T) {
 		Color:   color.White,
 	}
 
-	err := text.Init()
+	err := text.Init(nil)
 	if err != nil {
 		t.Fatalf("Text.Init() failed: %v", err)
 	}
@@ -172,7 +172,7 @@ func TestTextWidgetWithCustomHeight(t *testing.T) {
 		Color:   color.White,
 	}
 
-	err := text.Init()
+	err := text.Init(nil)
 	if err != nil {
 		t.Fatalf("Text.Init() failed: %v", err)
 	}
@@ -191,7 +191,7 @@ func TestTextWidgetWithOffset(t *testing.T) {
 		Color:   color.White,
 	}
 
-	err := text.Init()
+	err := text.Init(nil)
 	if err != nil {
 		t.Fatalf("Text.Init() failed: %v", err)
 	}
@@ -212,7 +212,7 @@ func TestTextWidgetMaxWidth(t *testing.T) {
 		Color:   color.White,
 	}
 
-	err := text.Init()
+	err := text.Init(nil)
 	if err != nil {
 		t.Fatalf("Text.Init() failed: %v", err)
 	}
@@ -243,7 +243,7 @@ func BenchmarkTextWithEmojis(b *testing.B) {
 					Color:   color.White,
 				}
 
-				err := text.Init()
+				err := text.Init(nil)
 				if err != nil {
 					b.Fatalf("Text.Init() failed: %v", err)
 				}

--- a/render/text_test.go
+++ b/render/text_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestTextDefault(t *testing.T) {
 	text := &Text{Content: "A"}
-	text.Init()
+	text.Init(nil)
 	im := PaintWidget(text, image.Rect(0, 0, 0, 0), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		".....",
@@ -27,7 +27,7 @@ func TestTextDefault(t *testing.T) {
 	assert.Equal(t, 8, h)
 
 	text = &Text{Content: "j!ÑÖ"}
-	text.Init()
+	text.Init(nil)
 	im = PaintWidget(text, image.Rect(0, 0, 0, 0), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"...." + ".." + ".w.w." + "w..w.",
@@ -49,7 +49,7 @@ func TestTextParameters(t *testing.T) {
 		Content: "ᚠӠ",
 		Font:    "6x13",
 	}
-	text.Init()
+	text.Init(nil)
 
 	im := PaintWidget(text, image.Rect(0, 0, 0, 0), 0)
 	assert.Equal(t, nil, checkImage([]string{
@@ -79,7 +79,7 @@ func TestTextParameters(t *testing.T) {
 		Offset:  -2,
 		Height:  10,
 	}
-	text.Init()
+	text.Init(nil)
 	im = PaintWidget(text, image.Rect(0, 0, 0, 0), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"......" + "......",
@@ -108,7 +108,7 @@ func TestTextFonts(t *testing.T) {
 		Content: "QqÖ!",
 		Font:    "6x13",
 	}
-	text.Init()
+	text.Init(nil)
 
 	im := PaintWidget(text, image.Rect(0, 0, 0, 0), 0)
 	assert.Equal(t, nil, checkImage([]string{
@@ -134,7 +134,7 @@ func TestTextFonts(t *testing.T) {
 		Content: "QqÖ!",
 		Font:    "Dina_r400-6",
 	}
-	text.Init()
+	text.Init(nil)
 	im = PaintWidget(text, image.Rect(0, 0, 0, 0), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"......" + "......" + ".w.w.." + "......",
@@ -156,7 +156,7 @@ func TestTextFonts(t *testing.T) {
 		Content: "QqÖ!",
 		Font:    "5x8",
 	}
-	text.Init()
+	text.Init(nil)
 	im = PaintWidget(text, image.Rect(0, 0, 0, 0), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"....." + "....." + "w..w." + ".....",
@@ -176,7 +176,7 @@ func TestTextFonts(t *testing.T) {
 		Content: "QqÖ!",
 		Font:    "tb-8",
 	}
-	text.Init()
+	text.Init(nil)
 	im = PaintWidget(text, image.Rect(0, 0, 0, 0), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"....." + "....." + "w..w." + "..",
@@ -198,5 +198,5 @@ func TestTextMissingFont(t *testing.T) {
 		Content: "QqÖ!",
 		Font:    "missing",
 	}
-	assert.Error(t, text.Init())
+	assert.Error(t, text.Init(nil))
 }

--- a/render/widget.go
+++ b/render/widget.go
@@ -4,6 +4,7 @@ import (
 	"image"
 
 	"github.com/tronbyt/gg"
+	"go.starlark.net/starlark"
 )
 
 // A Widget is a self-contained object that can render itself as an image.
@@ -16,7 +17,7 @@ type Widget interface {
 
 // Widgets can require initialization
 type WidgetWithInit interface {
-	Init() error
+	Init(*starlark.Thread) error
 }
 
 // WidgetStaticSize has inherent size and width known before painting.

--- a/render/wrappedtext.go
+++ b/render/wrappedtext.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/tronbyt/gg"
 	"github.com/tronbyt/pixlet/tools/i18n"
+	"go.starlark.net/starlark"
 	"golang.org/x/image/font"
 	"golang.org/x/text/unicode/bidi"
 )
@@ -57,9 +58,9 @@ type WrappedText struct {
 	face font.Face
 }
 
-func (tw *WrappedText) Init() error {
+func (tw *WrappedText) Init(thread *starlark.Thread) error {
 	if tw.Font == "" {
-		tw.Font = DefaultFontFace
+		tw.Font = getDefaultFont(thread)
 	}
 
 	face, err := GetFont(tw.Font)

--- a/render/wrappedtext_test.go
+++ b/render/wrappedtext_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestWrappedTextWithBounds(t *testing.T) {
 	text := &WrappedText{Content: "AB CD."}
-	assert.NoError(t, text.Init())
+	assert.NoError(t, text.Init(nil))
 
 	// Sufficient space to fit on single line
 	im := PaintWidget(text, image.Rect(0, 0, 25, 8), 0)
@@ -66,7 +66,7 @@ func TestWrappedTextWithBounds(t *testing.T) {
 func TestWrappedTextWithsize(t *testing.T) {
 	// Weight and Height parameters override the bounds
 	text := &WrappedText{Content: "AB CD.", Width: 7, Height: 12}
-	assert.NoError(t, text.Init())
+	assert.NoError(t, text.Init(nil))
 	im := PaintWidget(text, image.Rect(0, 0, 40, 40), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"....." + "..",
@@ -85,7 +85,7 @@ func TestWrappedTextWithsize(t *testing.T) {
 
 	// Height can be overridden separately
 	text = &WrappedText{Content: "AB CD.", Height: 12}
-	assert.NoError(t, text.Init())
+	assert.NoError(t, text.Init(nil))
 	im = PaintWidget(text, image.Rect(0, 0, 9, 40), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"....." + "....",
@@ -104,7 +104,7 @@ func TestWrappedTextWithsize(t *testing.T) {
 
 	// Ditto for Width
 	text = &WrappedText{Content: "AB CD.", Width: 3}
-	assert.NoError(t, text.Init())
+	assert.NoError(t, text.Init(nil))
 	im = PaintWidget(text, image.Rect(0, 0, 9, 5), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"...",
@@ -119,7 +119,7 @@ func TestWrappedTextLineSpacing(t *testing.T) {
 
 	// Single pixel line space
 	text := &WrappedText{Content: "AB CD.", LineSpacing: 1}
-	assert.NoError(t, text.Init())
+	assert.NoError(t, text.Init(nil))
 	im := PaintWidget(text, image.Rect(0, 0, 21, 16), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"....." + ".......",
@@ -142,7 +142,7 @@ func TestWrappedTextLineSpacing(t *testing.T) {
 
 	// Add another one
 	text = &WrappedText{Content: "AB CD.", LineSpacing: 2}
-	assert.NoError(t, text.Init())
+	assert.NoError(t, text.Init(nil))
 	im = PaintWidget(text, image.Rect(0, 0, 21, 16), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"....." + ".......",
@@ -167,7 +167,7 @@ func TestWrappedTextLineSpacing(t *testing.T) {
 func TestWrappedTextAlignment(t *testing.T) {
 	// Default to left align.
 	text := &WrappedText{Content: "AB CD."}
-	assert.NoError(t, text.Init())
+	assert.NoError(t, text.Init(nil))
 	im := PaintWidget(text, image.Rect(0, 0, 21, 16), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"......." + ".....",
@@ -190,7 +190,7 @@ func TestWrappedTextAlignment(t *testing.T) {
 
 	// Right alignment.
 	text = &WrappedText{Content: "AB CD.", Align: "right"}
-	assert.NoError(t, text.Init())
+	assert.NoError(t, text.Init(nil))
 	im = PaintWidget(text, image.Rect(0, 0, 21, 16), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"......." + ".....",
@@ -213,7 +213,7 @@ func TestWrappedTextAlignment(t *testing.T) {
 
 	// Center alignment.
 	text = &WrappedText{Content: "AB CD.", Align: "center"}
-	assert.NoError(t, text.Init())
+	assert.NoError(t, text.Init(nil))
 	im = PaintWidget(text, image.Rect(0, 0, 21, 16), 0)
 	assert.Equal(t, nil, checkImage([]string{
 		"......." + ".....",
@@ -237,5 +237,5 @@ func TestWrappedTextAlignment(t *testing.T) {
 
 func TestWrappedTextMissingFont(t *testing.T) {
 	text := &WrappedText{Content: "AB CD.", Font: "missing"}
-	assert.Error(t, text.Init())
+	assert.Error(t, text.Init(nil))
 }

--- a/runtime/applet.go
+++ b/runtime/applet.go
@@ -24,6 +24,7 @@ import (
 	starlibzip "github.com/qri-io/starlib/zipfile"
 	"github.com/tronbyt/pixlet/manifest"
 	"github.com/tronbyt/pixlet/runtime/modules/encoding/yaml"
+	"github.com/tronbyt/pixlet/runtime/modules/render_runtime/metadata"
 	starlibjson "go.starlark.net/lib/json"
 	starlibmath "go.starlark.net/lib/math"
 	starlibtime "go.starlark.net/lib/time"
@@ -118,10 +119,10 @@ func WithPrintDisabled() AppletOption {
 	return WithPrintFunc(func(thread *starlark.Thread, msg string) {})
 }
 
-func WithMetadata(m render_runtime.Metadata) AppletOption {
+func WithMetadata(m metadata.Metadata) AppletOption {
 	return func(a *Applet) error {
 		a.initializers = append(a.initializers, func(t *starlark.Thread) *starlark.Thread {
-			render_runtime.AttachToThread(t, m)
+			metadata.AttachToThread(t, m)
 			return t
 		})
 		return nil

--- a/runtime/gen/type.tmpl
+++ b/runtime/gen/type.tmpl
@@ -52,7 +52,7 @@ func new{{.GoName}}(
 {{end}}
 
 {{if .HasInit}}
-	if err := w.Init(); err != nil {
+	if err := w.Init(thread); err != nil {
 		return nil, err
 	}
 {{end}}

--- a/runtime/modules/animation_runtime/generated.go
+++ b/runtime/modules/animation_runtime/generated.go
@@ -728,7 +728,7 @@ func newTransformation(
 
 	w.frame_count = starlark.NewBuiltin("frame_count", transformationFrameCount)
 
-	if err := w.Init(); err != nil {
+	if err := w.Init(thread); err != nil {
 		return nil, err
 	}
 

--- a/runtime/modules/render_runtime/generated.go
+++ b/runtime/modules/render_runtime/generated.go
@@ -760,7 +760,7 @@ func newEmoji(
 
 	w.frame_count = starlark.NewBuiltin("frame_count", emojiFrameCount)
 
-	if err := w.Init(); err != nil {
+	if err := w.Init(thread); err != nil {
 		return nil, err
 	}
 
@@ -918,7 +918,7 @@ func newImage(
 
 	w.frame_count = starlark.NewBuiltin("frame_count", imageFrameCount)
 
-	if err := w.Init(); err != nil {
+	if err := w.Init(thread); err != nil {
 		return nil, err
 	}
 
@@ -2414,7 +2414,7 @@ func newText(
 
 	w.frame_count = starlark.NewBuiltin("frame_count", textFrameCount)
 
-	if err := w.Init(); err != nil {
+	if err := w.Init(thread); err != nil {
 		return nil, err
 	}
 
@@ -2601,7 +2601,7 @@ func newWrappedText(
 
 	w.frame_count = starlark.NewBuiltin("frame_count", wrappedtextFrameCount)
 
-	if err := w.Init(); err != nil {
+	if err := w.Init(thread); err != nil {
 		return nil, err
 	}
 

--- a/runtime/modules/render_runtime/metadata/metadata.go
+++ b/runtime/modules/render_runtime/metadata/metadata.go
@@ -1,0 +1,46 @@
+package metadata
+
+import (
+	"errors"
+
+	"go.starlark.net/starlark"
+)
+
+const threadMetadataKey = "github.com/tronbyt/pixlet/runtime/$metadata"
+
+func AttachToThread(t *starlark.Thread, m Metadata) {
+	t.SetLocal(threadMetadataKey, m)
+}
+
+var ErrNoMetadata = errors.New("no metadata available")
+
+func FromThread(thread *starlark.Thread) (Metadata, error) {
+	if thread == nil {
+		return Metadata{}, ErrNoMetadata
+	}
+	m, ok := thread.Local(threadMetadataKey).(Metadata)
+	if !ok {
+		return Metadata{}, ErrNoMetadata
+	}
+	return m, nil
+}
+
+type Metadata struct {
+	Width  int
+	Height int
+	Is2x   bool
+}
+
+func (m Metadata) ScaledWidth() int {
+	if m.Is2x {
+		return m.Width * 2
+	}
+	return m.Width
+}
+
+func (m Metadata) ScaledHeight() int {
+	if m.Is2x {
+		return m.Height * 2
+	}
+	return m.Height
+}

--- a/server/loader/loader.go
+++ b/server/loader/loader.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/tronbyt/pixlet/encode"
 	"github.com/tronbyt/pixlet/runtime"
-	"github.com/tronbyt/pixlet/runtime/modules/render_runtime"
+	"github.com/tronbyt/pixlet/runtime/modules/render_runtime/metadata"
 	"github.com/tronbyt/pixlet/schema"
 	"go.starlark.net/starlark"
 )
@@ -217,7 +217,7 @@ func (l *Loader) CallSchemaHandler(ctx context.Context, config map[string]string
 
 func (l *Loader) loadApplet() error {
 	opts := []runtime.AppletOption{
-		runtime.WithMetadata(render_runtime.Metadata{
+		runtime.WithMetadata(metadata.Metadata{
 			Width:  l.width,
 			Height: l.height,
 			Is2x:   l.output2x,
@@ -312,7 +312,7 @@ func RenderApplet(path string, config map[string]string, width, height, magnify,
 	}
 
 	opts := []runtime.AppletOption{
-		runtime.WithMetadata(render_runtime.Metadata{
+		runtime.WithMetadata(metadata.Metadata{
 			Width:  width,
 			Height: height,
 			Is2x:   filters.Output2x,


### PR DESCRIPTION
Changes the default font to `terminus-16` when rendering to 2x. There are a lot of small changes in this PR, but it's because I had to change the `Init()` function to `Init(*starlark.Thread)` so that it can check whether the render is 2x or not. Also changes a couple of the default text values from `var` to `const`.

Fixes #264 