### PR TITLE
feat(runtime): add `canvas.size()`

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -177,11 +177,12 @@ def main():
 The `render.star` module also provides `canvas`, which lets an app
 fetch information about the current output configuration.
 
-| Function       | Description                                                            |
-|----------------|------------------------------------------------------------------------|
-| `width(raw?)`  | Returns the device width in px. Pass `raw` to get the unscaled value.  |
-| `height(raw?)` | Returns the canvas height in px. Pass `raw` to get the unscaled value. |
-| `is2x()`       | Returns true if the device renders at 2x resolution.                   |
+| Function       | Description                                                                                   |
+|----------------|-----------------------------------------------------------------------------------------------|
+| `width(raw?)`  | Returns the device width in px. Pass `raw` to get the unscaled value.                         |
+| `height(raw?)` | Returns the canvas height in px. Pass `raw` to get the unscaled value.                        |
+| `size(raw?)`   | Returns a tuple with the canvas width and height in px. Pass `raw` to get the unscaled value. |
+| `is2x()`       | Returns true if the device renders at 2x resolution.                                          |
 
 ```starlark
 load("render.star", "render", "canvas")

--- a/runtime/gen/header/render.tmpl
+++ b/runtime/gen/header/render.tmpl
@@ -51,6 +51,7 @@ func LoadRenderModule() (starlark.StringDict, error) {
 				Members: starlark.StringDict{
 					"width":  starlark.NewBuiltin("width", dimension(dimensionWidth)),
 					"height": starlark.NewBuiltin("height", dimension(dimensionHeight)),
+					"size":   starlark.NewBuiltin("size", size),
 					"is2x":   starlark.NewBuiltin("is2x", is2x),
 				},
 			},

--- a/runtime/modules/render_runtime/generated.go
+++ b/runtime/modules/render_runtime/generated.go
@@ -79,6 +79,7 @@ func LoadRenderModule() (starlark.StringDict, error) {
 				Members: starlark.StringDict{
 					"width":  starlark.NewBuiltin("width", dimension(dimensionWidth)),
 					"height": starlark.NewBuiltin("height", dimension(dimensionHeight)),
+					"size":   starlark.NewBuiltin("size", size),
 					"is2x":   starlark.NewBuiltin("is2x", is2x),
 				},
 			},

--- a/runtime/modules/render_runtime/metadata.go
+++ b/runtime/modules/render_runtime/metadata.go
@@ -56,6 +56,35 @@ func dimension(d dimensionType) func(*starlark.Thread, *starlark.Builtin, starla
 	}
 }
 
+func size(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	m, err := metadata.FromThread(thread)
+	if err != nil {
+		return nil, err
+	}
+
+	var raw bool
+
+	if err := starlark.UnpackArgs(
+		"size",
+		args, kwargs,
+		"raw?", &raw,
+	); err != nil {
+		return nil, fmt.Errorf("unpacking arguments for size: %w", err)
+	}
+
+	var w, h int
+	if raw {
+		w, h = m.Width, m.Height
+	} else {
+		w, h = m.ScaledWidth(), m.ScaledHeight()
+	}
+
+	return starlark.Tuple([]starlark.Value{
+		starlark.MakeInt(w),
+		starlark.MakeInt(h),
+	}), nil
+}
+
 func is2x(thread *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
 	m, err := metadata.FromThread(thread)
 	if err != nil {


### PR DESCRIPTION
This PR adds a `canvas.size()` function which will return `(width, height)`, similar to many of the widget `size()` functions. I've found that I often write
```starlark
width, height = canvas.width(), canvas.height()
```
and this PR will simplify those to
```starlark
width, height = canvas.size()
```