### PR TITLE
fix(cmd): pixlet check panic

### DIFF
--- a/cmd/render.go
+++ b/cmd/render.go
@@ -183,7 +183,7 @@ func render(cmd *cobra.Command, args []string) error {
 	case "webp":
 		imageFormat = loader.ImageWebP
 		outPath += ".webp"
-		if cmd.Flags().Lookup(webpLevelFlag).Changed {
+		if flag := cmd.Flags().Lookup(webpLevelFlag); flag != nil && flag.Changed {
 			encode.SetWebPLevel(webpLevel)
 		}
 	case "gif":

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -64,7 +64,7 @@ func serve(cmd *cobra.Command, args []string) error {
 	switch serveFormat {
 	case "webp":
 		imageFormat = loader.ImageWebP
-		if cmd.Flags().Lookup(webpLevelFlag).Changed {
+		if flag := cmd.Flags().Lookup(webpLevelFlag); flag != nil && flag.Changed {
 			encode.SetWebPLevel(webpLevel)
 		}
 	case "gif":


### PR DESCRIPTION
When I added `--webp-level` in #269, I added some code that checks if the flag has changed to determine whether to override the level https://github.com/tronbyt/pixlet/blob/88e6c3f84b666e73f6458be316d9fc4f81faf447/cmd/render.go#L186-L188

Turns out, `pixlet check` calls `pixlet render`, but with the `pixlet check` command, meaning the flag doesn't exist. I should be able to fix this by checking if the flag is not `nil` before checking if it has changed.

Fixes #274