### PR TITLE
fix(serve): exit if HTTP server fails to start

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -79,5 +79,5 @@ func serve(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return s.Run()
+	return s.Run(cmd.Context())
 }

--- a/server/browser/serve.go
+++ b/server/browser/serve.go
@@ -1,11 +1,25 @@
 package browser
 
 import (
+	"context"
+	"errors"
 	"log"
 	"net/http"
 )
 
-func (b *Browser) serveHTTP() error {
+func (b *Browser) serveHTTP(ctx context.Context) error {
+	server := &http.Server{
+		Addr:    b.addr,
+		Handler: b.r,
+	}
+	go func() {
+		<-ctx.Done()
+		_ = server.Close()
+	}()
+
 	log.Printf("listening at http://%s%s\n", b.addr, b.path)
-	return http.ListenAndServe(b.addr, b.r)
+	if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+	return nil
 }

--- a/server/loader/loader.go
+++ b/server/loader/loader.go
@@ -108,11 +108,13 @@ func NewLoader(
 // If there is an on-demand request, it's processed and sent back to the caller
 // and sent out as an update. If there is a file change, we update the applet
 // and send out the update over the updatesChan.
-func (l *Loader) Run() error {
+func (l *Loader) Run(ctx context.Context) error {
 	config := make(map[string]string)
 
 	for {
 		select {
+		case <-ctx.Done():
+			return ctx.Err()
 		case c := <-l.configChanges:
 			config = c
 		case <-l.requestedChanges:

--- a/server/watcher.go
+++ b/server/watcher.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -34,7 +35,7 @@ func NewWatcher(filename string, fileChanges chan bool) *Watcher {
 // the WRITE and CREATE events since VIM will write to a swap and then create
 // the file on save. VSCode does a WRITE and then a CHMOD, so tracking WRITE
 // catches the changes for VSCode exactly once.
-func (w *Watcher) Run() error {
+func (w *Watcher) Run(ctx context.Context) error {
 	// check if path exists, and whether it is a directory or a file
 	info, err := os.Stat(w.path)
 	if err != nil {
@@ -56,6 +57,8 @@ func (w *Watcher) Run() error {
 
 	for {
 		select {
+		case <-ctx.Done():
+			return ctx.Err()
 		case event, ok := <-watcher.Events:
 			if !ok {
 				return fmt.Errorf("watcher events channel closed unexpectedly")


### PR DESCRIPTION
Sometimes I accidentally run `pixlet serve` in multiple terminal tabs. I'd expect the second process to exit with `bind: address already in use`, but at the moment it silently blocks forever. This PR passes a shared `context.Context` to the parallel serve functions so that they exit early if one fails.