### PR TITLE
feat(library): Export libpixletAPIVersion as a C symbol

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ bench:
 
 build: gzip_fonts
 	$(GO_CMD) build $(LDFLAGS) $(TAGS) -o $(BINARY) github.com/tronbyt/pixlet
-	CGO_LDFLAGS=$(CGO_LDFLAGS) $(GO_CMD) build $(LDFLAGS) -tags lib -o $(LIBRARY) -buildmode=c-shared library/library.go
+	CGO_LDFLAGS=$(CGO_LDFLAGS) $(GO_CMD) build $(LDFLAGS) -tags lib -o $(LIBRARY) -buildmode=c-shared ./library
 
 widgets:
 	 $(GO_CMD) run ./runtime/gen

--- a/library/library.go
+++ b/library/library.go
@@ -5,6 +5,8 @@ package main
 /*
 #include <stdbool.h>
 #include <stdlib.h>
+
+// When making breaking changes to the library API, increment libpixletAPIVersion in library/version.c.
 */
 import "C"
 
@@ -23,9 +25,6 @@ import (
 )
 
 const (
-	// Increment this if you make breaking changes to this file
-	libpixletAPIVersion = 1
-
 	statusErrInvalidConfig  = -1
 	statusErrRenderFailure  = -2
 	statusErrInvalidFilters = -3
@@ -185,11 +184,6 @@ func init_redis_cache(redisURL *C.char) {
 	cache := runtime.NewRedisCache(C.GoString(redisURL))
 	runtime.InitHTTP(cache)
 	runtime.InitCache(cache)
-}
-
-//export get_version
-func get_version() C.int {
-	return C.int(libpixletAPIVersion)
 }
 
 func main() {}

--- a/library/version.c
+++ b/library/version.c
@@ -1,0 +1,2 @@
+// This file defines libpixletAPIVersion. Increment this value if you make breaking changes to the library API.
+const int libpixletAPIVersion = 1;


### PR DESCRIPTION
Exports the `libpixletAPIVersion` as a C symbol for direct loading by external programs (e.g., Python ctypes).

- Removed the `get_version` Go function, as its functionality is now replaced by the directly exported C symbol.
- Introduced `library/version.c` to define `libpixletAPIVersion`, ensuring proper symbol export.
- Revised `Makefile` to compile the entire `library` directory, including `library/version.c`.
- Updated comments in `library/library.go` and `library/version.c` to clarify version increment instructions.