### PR TITLE
feat(render): add shell completions for schema fields

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,9 +1,14 @@
 package cmd
 
 import (
+	"fmt"
+	"slices"
 	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/tronbyt/pixlet/runtime"
+	"github.com/tronbyt/pixlet/schema"
 )
 
 var formats = []string{"webp", "gif", "avif"}
@@ -46,4 +51,62 @@ func completeWebPLevel(*cobra.Command, []string, string) ([]string, cobra.ShellC
 		s = append(s, strconv.Itoa(i))
 	}
 	return s, cobra.ShellCompDirectiveNoFileComp
+}
+
+func completeRender(_ *cobra.Command, args []string, toComplete string) ([]cobra.Completion, cobra.ShellCompDirective) {
+	if len(args) == 0 {
+		return []string{"star"}, cobra.ShellCompDirectiveFilterFileExt
+	}
+
+	applet, err := runtime.NewAppletFromPath(args[0])
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+	defer applet.Close()
+
+	if applet.Schema == nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	if id, _, ok := strings.Cut(toComplete, "="); ok {
+		// Complete field options
+		if idx := slices.IndexFunc(applet.Schema.Fields, func(f schema.SchemaField) bool {
+			return f.ID == id
+		}); idx != -1 {
+			field := applet.Schema.Fields[idx]
+			prefix := field.ID + "="
+			switch field.Type {
+			case "color":
+				return []string{prefix + "#" + strings.TrimPrefix(field.Default, "#")}, cobra.ShellCompDirectiveNoFileComp
+			case "onoff":
+				return []string{prefix + "true", prefix + "false"}, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveKeepOrder
+			case "dropdown":
+				s := make([]string, 0, len(field.Options))
+				for _, option := range field.Options {
+					cmp := prefix + option.Value + "\t" + option.Text
+					if field.Default == option.Value && !strings.Contains(strings.ToLower(cmp), "(default)") {
+						cmp += " (Default)"
+					}
+					s = append(s, cmp)
+				}
+				return s, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveKeepOrder
+			}
+			if field.Default != "" {
+				return []string{prefix + field.Default}, cobra.ShellCompDirectiveNoFileComp
+			}
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+	}
+
+	// Complete field IDs
+	s := make([]string, 0, len(applet.Schema.Fields))
+	for _, field := range applet.Schema.Fields {
+		alreadySet := slices.ContainsFunc(args[1:], func(s string) bool {
+			return strings.HasPrefix(s, field.ID+"=")
+		})
+		if !alreadySet {
+			s = append(s, fmt.Sprintf("%s=\t%s - %s - %s", field.ID, field.Type, field.Name, field.Description))
+		}
+	}
+	return s, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveKeepOrder | cobra.ShellCompDirectiveNoSpace
 }

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -64,7 +64,7 @@ The path argument should be the path to the Pixlet app to run. The
 app can be a single file with the .star extension, or a directory
 containing multiple Starlark files and resources.
 	`,
-		ValidArgsFunction: cobra.FixedCompletions([]string{"star"}, cobra.ShellCompDirectiveFilterFileExt),
+		ValidArgsFunction: completeRender,
 	}
 
 	cmd.Flags().StringVarP(&opts.configJSON, "config", "c", opts.configJSON, "Config file in json format")


### PR DESCRIPTION
`pixlet render . <TAB>` will now complete schema field names and values (when possible)