### PR TITLE
feat: check manifest `minPixletVersion` before rendering an app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,20 +6,20 @@ GO_CMD = go
 ifeq ($(OS),Windows_NT)
 	BINARY = pixlet.exe
 	LIBRARY = pixlet.dll
-	LDFLAGS = -ldflags="-s '-extldflags=-static -lsharpyuv' -X 'github.com/tronbyt/pixlet/cmd.Version=$(GIT_COMMIT)'"
+	LDFLAGS = -ldflags="-s '-extldflags=-static -lsharpyuv' -X 'github.com/tronbyt/pixlet/runtime.Version=$(GIT_COMMIT)'"
 	TAGS = -tags timetzdata,gzip_fonts
 else
 	BINARY = pixlet
 	LIBRARY = libpixlet.so
 	ifeq ($(STATIC),1)
 		TAGS = -tags netgo,osusergo,gzip_fonts
-		LDFLAGS = -ldflags="-s -w -linkmode=external '-extldflags=-static -lsharpyuv -lm' -X 'github.com/tronbyt/pixlet/cmd.Version=$(GIT_COMMIT)'"
+		LDFLAGS = -ldflags="-s -w -linkmode=external '-extldflags=-static -lsharpyuv -lm' -X 'github.com/tronbyt/pixlet/runtime.Version=$(GIT_COMMIT)'"
 		ifeq ($(OS),Linux)
 			CGO_LDFLAGS="-Wl,-Bstatic -lwebp -lwebpdemux -lwebpmux -lsharpyuv -Wl,-Bdynamic"
 		endif
 	else
 		TAGS = -tags gzip_fonts
-		LDFLAGS = -ldflags="-s -w -X 'github.com/tronbyt/pixlet/cmd.Version=$(GIT_COMMIT)'"
+		LDFLAGS = -ldflags="-s -w -X 'github.com/tronbyt/pixlet/runtime.Version=$(GIT_COMMIT)'"
 	endif
 endif
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -4,16 +4,15 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"github.com/tronbyt/pixlet/runtime"
 )
-
-var Version string
 
 func NewVersionCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Show the version of Pixlet",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("Pixlet version: %s\n", Version)
+			fmt.Printf("Pixlet version: %s\n", runtime.Version)
 		},
 		ValidArgsFunction: cobra.NoFileCompletions,
 	}

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/zachomedia/go-bdf v0.0.0-20220611021443-a3af701111be
 	go.starlark.net v0.0.0-20251109183026-be02852a5e1f
 	golang.org/x/image v0.33.0
+	golang.org/x/mod v0.29.0
 	golang.org/x/sync v0.18.0
 	golang.org/x/text v0.31.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -93,7 +94,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/exp v0.0.0-20250911091902-df9299821621 // indirect
-	golang.org/x/mod v0.29.0 // indirect
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/tools v0.38.0 // indirect

--- a/library/library.go
+++ b/library/library.go
@@ -27,16 +27,17 @@ import (
 )
 
 const (
-	statusErrInvalidConfig   = -1
-	statusErrRenderFailure   = -2
-	statusErrInvalidFilters  = -3
-	statusErrHandlerFailure  = -4
-	statusErrInvalidPath     = -5
-	statusErrStarSuffix      = -6
-	statusErrUnknownApplet   = -7
-	statusErrSchemaFailure   = -8
-	statusErrInvalidTimezone = -9
-	statusErrInvalidLocale   = -10
+	statusErrInvalidConfig    = -1
+	statusErrRenderFailure    = -2
+	statusErrInvalidFilters   = -3
+	statusErrHandlerFailure   = -4
+	statusErrInvalidPath      = -5
+	statusErrStarSuffix       = -6
+	statusErrUnknownApplet    = -7
+	statusErrSchemaFailure    = -8
+	statusErrInvalidTimezone  = -9
+	statusErrInvalidLocale    = -10
+	statusErrMinPixletVersion = -11
 )
 
 // render_app renders an applet based on the provided parameters.
@@ -118,8 +119,13 @@ func render_app(
 	)
 
 	messagesJSON, _ := json.Marshal(messages)
+
 	if err != nil {
-		return nil, C.int(statusErrRenderFailure), C.CString(string(messagesJSON)), C.CString(fmt.Sprintf("error rendering: %v", err))
+		status := statusErrRenderFailure
+		if errors.Is(err, runtime.ErrMinPixletVersion) {
+			status = statusErrMinPixletVersion
+		}
+		return nil, C.int(status), C.CString(string(messagesJSON)), C.CString(fmt.Sprintf("error rendering: %v", err))
 	}
 
 	return (*C.uchar)(C.CBytes(result)), C.int(len(result)), C.CString(string(messagesJSON)), nil
@@ -133,6 +139,8 @@ func errorStatus(err error) int {
 			return statusErrInvalidPath
 		case errors.Is(err, runtime.ErrStarSuffix):
 			return statusErrStarSuffix
+		case errors.Is(err, runtime.ErrMinPixletVersion):
+			return statusErrMinPixletVersion
 		}
 	}
 	return statusErrUnknownApplet

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -40,6 +40,9 @@ type Manifest struct {
 
 	// Supports2x indicates whether an app supports 2x render scaling.
 	Supports2x bool `json:"supports2x,omitempty" yaml:"supports2x,omitempty"`
+
+	// MinPixletVersion returns an error if the current version of Pixlet is too old.
+	MinPixletVersion string `json:"minPixletVersion,omitempty" yaml:"minPixletVersion,omitempty"`
 }
 
 // LoadManifest reads a manifest from an io.Reader, with the most common reader

--- a/runtime/version.go
+++ b/runtime/version.go
@@ -1,0 +1,3 @@
+package runtime
+
+var Version = "dev"

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -26,21 +26,21 @@ do
 	LIBPIXLET=libpixlet.so
 	if [[ $ARCH == "linux-arm64"  ]]; then
 		echo "linux-arm64"
-		CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -ldflags="-w -s '-extldflags=-static -lsharpyuv' -X 'github.com/tronbyt/pixlet/cmd.Version=${PIXLET_VERSION}'" -tags=gzip_fonts -trimpath -o "build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/${PIXLET}" github.com/tronbyt/pixlet
+		CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -ldflags="-w -s '-extldflags=-static -lsharpyuv' -X 'github.com/tronbyt/pixlet/runtime.Version=${PIXLET_VERSION}'" -tags=gzip_fonts -trimpath -o "build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/${PIXLET}" github.com/tronbyt/pixlet
 		CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -ldflags="-w -s" -tags=lib,gzip_fonts -trimpath -o "build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/${LIBPIXLET}" -buildmode=c-shared library/library.go
 	elif [[ $ARCH == "linux-amd64"  ]]; then
 		echo "linux-amd64"
-		CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -ldflags="-w -s '-extldflags=-static -lsharpyuv' -X 'github.com/tronbyt/pixlet/cmd.Version=${PIXLET_VERSION}'" -tags=gzip_fonts -trimpath -o "build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/${PIXLET}" github.com/tronbyt/pixlet
+		CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -ldflags="-w -s '-extldflags=-static -lsharpyuv' -X 'github.com/tronbyt/pixlet/runtime.Version=${PIXLET_VERSION}'" -tags=gzip_fonts -trimpath -o "build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/${PIXLET}" github.com/tronbyt/pixlet
 		CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -ldflags="-w -s" -tags=lib,gzip_fonts -trimpath -o "build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/${LIBPIXLET}" -buildmode=c-shared library/library.go
 	elif [[ $ARCH == "windows-amd64"  ]]; then
 		echo "windows-amd64"
 		PIXLET=pixlet.exe
 		LIBPIXLET=pixlet.dll
-		go build -ldflags="-w -s '-extldflags=-static -lsharpyuv' -X 'github.com/tronbyt/pixlet/cmd.Version=${PIXLET_VERSION}'" -tags=timetzdata,gzip_fonts -trimpath -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/${PIXLET} github.com/tronbyt/pixlet
+		go build -ldflags="-w -s '-extldflags=-static -lsharpyuv' -X 'github.com/tronbyt/pixlet/runtime.Version=${PIXLET_VERSION}'" -tags=timetzdata,gzip_fonts -trimpath -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/${PIXLET} github.com/tronbyt/pixlet
 		go build -ldflags="-w -s '-extldflags=-static -lsharpyuv'" -tags=lib,gzip_fonts -trimpath -o "build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/${LIBPIXLET}" library/library.go
 	else
 		echo "other"
-		CGO_CFLAGS="-I/tmp/${LIBWEBP_VERSION}/${ARCH}/include" CGO_LDFLAGS="-L/tmp/${LIBWEBP_VERSION}/${ARCH}/lib" CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -ldflags="-w -s -X 'github.com/tronbyt/pixlet/cmd.Version=${PIXLET_VERSION}'" -tags=gzip_fonts -trimpath -o "build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/${PIXLET}" github.com/tronbyt/pixlet
+		CGO_CFLAGS="-I/tmp/${LIBWEBP_VERSION}/${ARCH}/include" CGO_LDFLAGS="-L/tmp/${LIBWEBP_VERSION}/${ARCH}/lib" CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -ldflags="-w -s -X 'github.com/tronbyt/pixlet/runtime.Version=${PIXLET_VERSION}'" -tags=gzip_fonts -trimpath -o "build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/${PIXLET}" github.com/tronbyt/pixlet
 		CGO_CFLAGS="-I/tmp/${LIBWEBP_VERSION}/${ARCH}/include" CGO_LDFLAGS="-L/tmp/${LIBWEBP_VERSION}/${ARCH}/lib" CGO_ENABLED=1 GOOS=$RELEASE_PLATFORM GOARCH=$RELEASE_ARCH go build -ldflags="-w -s" -tags=lib,gzip_fonts -trimpath -o build/${RELEASE_PLATFORM}_${RELEASE_ARCH}/libpixlet.so library/library.go
 	fi
 


### PR DESCRIPTION
When loading an app, Pixlet will check whether its version is equal to or newer than `minPixletVersion` in `manifest.yaml`. This check will be skipped if Pixlet does not have a valid version string or if `minPixletVersion` is an empty string. The library has a new status code `-11` which indicates a version failure.

The Homebrew formulas will need to be updated before this will work:
- Go's semver package requires versions begin with `v`
- The `Version` var has been moved from `github.com/tronbyt/pixlet/cmd` to `github.com/tronbyt/pixlet/runtime`

I'll include these changes in the PR when this is released.