### PR TITLE
feat(render): add `hold_frames` to `render.Image`

### DIFF
--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -195,6 +195,7 @@ the `delay` attribute.
 | `width` | `int` | Scale image to this width | N |
 | `height` | `int` | Scale image to this height | N |
 | `delay` | `int` | (Read-only) Frame delay in ms, for animated GIFs | N |
+| `hold_frames` | `int` | Number of render frames to hold each animation frame, default is 1. | N |
 
 ## Marquee
 Marquee scrolls its child horizontally or vertically.

--- a/render/image_test.go
+++ b/render/image_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // A base4 encoded PNG depicting a red rectangle with a centered red
@@ -104,6 +105,8 @@ func TestImageScaleAspectRatioHeight(t *testing.T) {
 	assert.Equal(t, 6, im.Bounds().Dy())
 }
 
+const testGIF = "R0lGODlhBQAEAPAAAAAAAAAAACH5BAF7AAAAIf8LTkVUU0NBUEUyLjADAQAAACwAAAAABQAEAAACBgRiaLmLBQAh+QQBewAAACwAAAAABQAEAAACBYRzpqhXACH5BAF7AAAALAAAAAAFAAQAAAIGDG6Qp8wFACH5BAF7AAAALAAAAAAFAAQAAAIGRIBnyMoFADs="
+
 func TestImageAnimatedGif(t *testing.T) {
 	// Animated 5x4 GIF with 4 frames:
 	//
@@ -116,8 +119,6 @@ func TestImageAnimatedGif(t *testing.T) {
 	// next row.
 	//
 	// GIF has no disposal method set, and a delay of 1230 ms
-
-	const testGIF = "R0lGODlhBQAEAPAAAAAAAAAAACH5BAF7AAAAIf8LTkVUU0NBUEUyLjADAQAAACwAAAAABQAEAAACBgRiaLmLBQAh+QQBewAAACwAAAAABQAEAAACBYRzpqhXACH5BAF7AAAALAAAAAAFAAQAAAIGDG6Qp8wFACH5BAF7AAAALAAAAAAFAAQAAAIGRIBnyMoFADs="
 
 	raw, _ := base64.StdEncoding.DecodeString(testGIF)
 	img := &Image{Src: string(raw)}
@@ -173,4 +174,18 @@ func TestImageAnimatedGif(t *testing.T) {
 		".xx..",
 		"...xx",
 	}, PaintWidget(img, image.Rect(0, 0, 100, 100), 5)))
+}
+
+func TestImageAnimatedGifWithHoldFrames(t *testing.T) {
+	raw, _ := base64.StdEncoding.DecodeString(testGIF)
+	img := &Image{Src: string(raw), HoldFrames: 2}
+	require.NoError(t, img.Init(nil))
+
+	assert.Equal(t, 8, img.FrameCount(image.Rect(0, 0, 0, 0)))
+	assert.Equal(t, img.frameImg(0), img.frameImg(1))
+	assert.NotEqual(t, img.frameImg(1), img.frameImg(2))
+	assert.Equal(t, img.frameImg(2), img.frameImg(3))
+	assert.Equal(t, img.frameImg(4), img.frameImg(5))
+	assert.NotEqual(t, img.frameImg(3), img.frameImg(4))
+	assert.Equal(t, img.frameImg(6), img.frameImg(7))
 }

--- a/runtime/modules/render_runtime/generated.go
+++ b/runtime/modules/render_runtime/generated.go
@@ -832,6 +832,8 @@ func newImage(
 		src    starlark.String
 		width  starlark.Int
 		height starlark.Int
+
+		hold_frames starlark.Int
 	)
 
 	if err := starlark.UnpackArgs(
@@ -840,6 +842,7 @@ func newImage(
 		"src", &src,
 		"width?", &width,
 		"height?", &height,
+		"hold_frames?", &hold_frames,
 	); err != nil {
 		return nil, fmt.Errorf("unpacking arguments for Image: %s", err)
 	}
@@ -860,6 +863,12 @@ func newImage(
 	}
 	w.Height = int(heightInt)
 
+	hold_framesInt, err := starlarkutil.AsInt64(hold_frames)
+	if err != nil {
+		return nil, fmt.Errorf("parsing hold_frames: %w", err)
+	}
+	w.HoldFrames = int(hold_framesInt)
+
 	w.size = starlark.NewBuiltin("size", imageSize)
 	w.frame_count = starlark.NewBuiltin("frame_count", imageFrameCount)
 	if err := w.Init(thread); err != nil {
@@ -879,6 +888,7 @@ func (w *Image) AttrNames() []string {
 		"width",
 		"height",
 		"delay",
+		"hold_frames",
 	}
 }
 
@@ -892,6 +902,8 @@ func (w *Image) Attr(name string) (starlark.Value, error) {
 		return starlark.MakeInt(int(w.Height)), nil
 	case "delay":
 		return starlark.MakeInt(int(w.Delay)), nil
+	case "hold_frames":
+		return starlark.MakeInt(int(w.HoldFrames)), nil
 	case "size":
 		return w.size.BindReceiver(w), nil
 	case "frame_count":


### PR DESCRIPTION
When adding 2x support to an app, I usually double the delay to make marquees scroll at the same speed. If an app has any animated images, doubling the delay also doubles the image. To fix this, this PR adds `hold_frames` as an optional parameter to `render.Image`. If set to a value > 1, each animation frame will be shown for the given number of render frames.