### PR TITLE
render: add wordbreak option to WrappedText widget

### DIFF
--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -503,6 +503,7 @@ Alignment of the text is controlled by passing one of the following `align` valu
 | `linespacing` | `int` | Controls spacing between lines | N |
 | `color` | `color` | Desired font color | N |
 | `align` | `str` | Text Alignment | N |
+| `wordbreak` | `bool` | If true, words longer than `width` will be broken across multiple lines. | N |
 
 #### Example
 ```

--- a/render/wrappedtext_test.go
+++ b/render/wrappedtext_test.go
@@ -239,3 +239,27 @@ func TestWrappedTextMissingFont(t *testing.T) {
 	text := &WrappedText{Content: "AB CD.", Font: "missing"}
 	assert.Error(t, text.Init(nil))
 }
+
+func TestWrappedTextWordBreak(t *testing.T) {
+	// A long word that definitely doesn't fit in 10 pixels.
+	// Default font is usually around 5-6 pixels wide per char.
+	content := "LONGLONGWORD"
+	width := 10
+
+	// Case 1: WordBreak = false (default)
+	text := &WrappedText{Content: content, Width: width}
+	assert.NoError(t, text.Init(nil))
+
+	bounds := text.PaintBounds(image.Rect(0, 0, 100, 100), 0)
+	// Should be single line height (e.g. 8 or similar)
+	singleLineHeight := bounds.Dy()
+
+	// Case 2: WordBreak = true
+	text2 := &WrappedText{Content: content, Width: width, WordBreak: true}
+	assert.NoError(t, text2.Init(nil))
+
+	bounds2 := text2.PaintBounds(image.Rect(0, 0, 100, 100), 0)
+
+	// Should be multiple lines, so height should be significantly larger.
+	assert.Greater(t, bounds2.Dy(), singleLineHeight, "WordBreak should wrap text and increase height")
+}

--- a/runtime/modules/render_runtime/generated.go
+++ b/runtime/modules/render_runtime/generated.go
@@ -2404,6 +2404,7 @@ func newWrappedText(
 		linespacing starlark.Int
 		color       starlark.String
 		align       starlark.String
+		wordbreak   starlark.Bool
 	)
 
 	if err := starlark.UnpackArgs(
@@ -2416,6 +2417,7 @@ func newWrappedText(
 		"linespacing?", &linespacing,
 		"color?", &color,
 		"align?", &align,
+		"wordbreak?", &wordbreak,
 	); err != nil {
 		return nil, fmt.Errorf("unpacking arguments for WrappedText: %s", err)
 	}
@@ -2455,6 +2457,8 @@ func newWrappedText(
 
 	w.Align = align.GoString()
 
+	w.WordBreak = bool(wordbreak)
+
 	w.frame_count = starlark.NewBuiltin("frame_count", wrappedtextFrameCount)
 	if err := w.Init(thread); err != nil {
 		return nil, err
@@ -2476,6 +2480,7 @@ func (w *WrappedText) AttrNames() []string {
 		"linespacing",
 		"color",
 		"align",
+		"wordbreak",
 	}
 }
 
@@ -2495,6 +2500,8 @@ func (w *WrappedText) Attr(name string) (starlark.Value, error) {
 		return w.starlarkColor, nil
 	case "align":
 		return starlark.String(w.Align), nil
+	case "wordbreak":
+		return starlark.Bool(w.WordBreak), nil
 	case "frame_count":
 		return w.frame_count.BindReceiver(w), nil
 	default:

--- a/runtime/secret_test.go
+++ b/runtime/secret_test.go
@@ -53,7 +53,7 @@ func TestSecretDecrypt(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEqual(t, encrypted, "")
 
-src := fmt.Sprintf(`
+	src := fmt.Sprintf(`
 load("render.star", "render")
 load("schema.star", "schema")
 load("secret.star", "secret")
@@ -103,7 +103,7 @@ func TestSecretDoesntDecryptWithoutKey(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEqual(t, encrypted, "")
 
-src := fmt.Sprintf(`
+	src := fmt.Sprintf(`
 load("render.star", "render")
 load("schema.star", "schema")
 load("secret.star", "secret")


### PR DESCRIPTION
This adds a 'wordbreak' boolean parameter to the WrappedText widget. When enabled, this allows words that are wider than the available width to be broken across multiple lines, preventing them from being clipped.