### PR TITLE
deps(go): bump go to 1.25.5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.4"
+          go-version: "1.25.5"
 
       - name: Install buildifier
         run: make install-buildifier
@@ -43,7 +43,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.4"
+          go-version: "1.25.5"
 
       - name: Install Node
         uses: actions/setup-node@v6
@@ -59,8 +59,8 @@ jobs:
           install: >-
             make
             curl
-            mingw-w64-x86_64-go
             mingw-w64-x86_64-toolchain
+          path-type: inherit
 
       - name: Install Linux dependencies
         if: matrix.os == 'ubuntu-24.04' || matrix.os == 'ubuntu-24.04-arm'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.4"
+          go-version: "1.25.5"
 
       - name: Install buildifier
         run: make install-buildifier
@@ -37,7 +37,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.4"
+          go-version: "1.25.5"
 
       - name: Install Node
         uses: actions/setup-node@v6
@@ -53,8 +53,8 @@ jobs:
           install: >-
             make
             curl
-            mingw-w64-x86_64-go
             mingw-w64-x86_64-toolchain
+          path-type: inherit
 
       - name: Install Linux dependencies
         if: matrix.os == 'ubuntu-24.04'

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN npm run build
 # Can't use Alpine because of
 # - https://github.com/golang/go/issues/54805: libpixlet.so can't be loaded dynamically
 # - https://github.com/python/cpython/issues/109332: CPython doesn't support musl
-FROM --platform=$BUILDPLATFORM golang:1.25.4 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.5 AS builder
 WORKDIR /pixlet
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tronbyt/pixlet
 
-go 1.25.4
+go 1.25.5
 
 require (
 	github.com/antchfx/xmlquery v1.5.0


### PR DESCRIPTION
Also: avoid installing two Go toolchains on Windows