### PR TITLE
feat(check): add recursive app traversal and skip broken apps

### DIFF
--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -43,6 +43,9 @@ type Manifest struct {
 
 	// MinPixletVersion returns an error if the current version of Pixlet is too old.
 	MinPixletVersion string `json:"minPixletVersion,omitempty" yaml:"minPixletVersion,omitempty"`
+
+	// Broken indicates that an app is intentionally broken and should be skipped by checks.
+	Broken bool `json:"broken,omitempty" yaml:"broken,omitempty"`
 }
 
 // LoadManifest reads a manifest from an io.Reader, with the most common reader


### PR DESCRIPTION
Implement recursive app traversal for the `check` command to find apps within subdirectories. Add a `--skip-broken` flag to skip apps explicitly marked as broken in their `manifest.yaml`. This enhancement allows for more flexible and efficient checking of multiple applications within a codebase.

- Introduce `skipBroken` option and `--skip-broken` flag.
- Implement `findApps` helper for recursive `manifest.yaml` discovery.
- Add `Broken` field to `manifest.Manifest` struct.
- Update `checkRun` to respect `skipBroken` and `m.Broken` status.
- Improve error handling for `ProfileApp`.