### PR TITLE
render: fix SVG transparency loss by avoiding JPEG encoding

### DIFF
--- a/render/image.go
+++ b/render/image.go
@@ -8,7 +8,6 @@ import (
 	"image/color"
 	"image/draw"
 	"image/gif"
-	"image/jpeg"
 
 	// register image formats
 	_ "image/jpeg"
@@ -150,17 +149,8 @@ func (p *Image) InitFromSVG(data []byte) error {
 	svgData.SetTarget(0, 0, float64(w), float64(h))
 	rgba := image.NewRGBA(image.Rect(0, 0, w, h))
 	svgData.Draw(rasterx.NewDasher(w, h, rasterx.NewScannerGV(w, h, rgba, rgba.Bounds())), 1)
-	buf := new(bytes.Buffer)
-	err := jpeg.Encode(buf, rgba, nil)
 
-	if err != nil {
-		return err
-	}
-
-	err = p.InitFromImage([]byte(buf.Bytes()))
-	if err != nil {
-		return err
-	}
+	p.imgs = []image.Image{rgba}
 
 	return nil
 }

--- a/render/image_test.go
+++ b/render/image_test.go
@@ -189,3 +189,35 @@ func TestImageAnimatedGifWithHoldFrames(t *testing.T) {
 	assert.NotEqual(t, img.frameImg(3), img.frameImg(4))
 	assert.Equal(t, img.frameImg(6), img.frameImg(7))
 }
+
+func TestImageSVG(t *testing.T) {
+	// Simple SVG: 10x10, left half red, right half transparent (default)
+	svg := `
+<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">
+  <rect x="0" y="0" width="5" height="10" fill="#FF0000"/>
+</svg>
+`
+	img := &Image{Src: svg}
+	err := img.Init(nil)
+	require.NoError(t, err)
+
+	w, h := img.Size()
+	assert.Equal(t, 10, w)
+	assert.Equal(t, 10, h)
+
+	im := PaintWidget(img, image.Rect(0, 0, 0, 0), 0)
+
+	// Expect left half red, right half transparent
+	assert.Equal(t, nil, checkImage([]string{
+		"rrrrr.....",
+		"rrrrr.....",
+		"rrrrr.....",
+		"rrrrr.....",
+		"rrrrr.....",
+		"rrrrr.....",
+		"rrrrr.....",
+		"rrrrr.....",
+		"rrrrr.....",
+		"rrrrr.....",
+	}, im))
+}


### PR DESCRIPTION
Previously, InitFromSVG would rasterize the SVG and then encode it to JPEG before decoding it back to an image. This caused the alpha channel to be lost, replacing transparent backgrounds with black. This change removes the intermediate JPEG encoding step and uses the rasterized RGBA image directly.