### PR TITLE
Enable `while` and `top-level control` in Starlark

### DIFF
--- a/runtime/applet.go
+++ b/runtime/applet.go
@@ -578,8 +578,10 @@ func (a *Applet) ensureLoaded(fsys fs.FS, pathToLoad string, currentlyLoading ..
 	case ".star":
 		globals, err := starlark.ExecFileOptions(
 			&syntax.FileOptions{
-				Set:       true,
-				Recursion: true,
+				Set:             true,
+				Recursion:       true,
+				While:           true,
+				TopLevelControl: true,
 			},
 			thread,
 			path.Join(a.ID, pathToLoad),

--- a/runtime/applet_test.go
+++ b/runtime/applet_test.go
@@ -172,6 +172,25 @@ def main(config):
 	assert.Equal(t, 3, len(roots))
 }
 
+func TestWhileStatement(t *testing.T) {
+	src := `
+load("render.star", "render")
+def main():
+    i = 0
+    while i < 3:
+        i += 1
+    if i != 3:
+        fail("while loop failed")
+    return render.Root(child=render.Box())
+`
+	app, err := NewApplet("test.star", []byte(src), WithTests(t))
+	assert.NoError(t, err)
+	assert.NotNil(t, app)
+	roots, err := app.Run(t.Context())
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(roots))
+}
+
 func TestLoadMultipleFiles(t *testing.T) {
 	mainSrc := `
 load("render.star", "render")


### PR DESCRIPTION
Enabled `While` and `TopLevelControl` options in `starlark.ExecFileOptions` to support while loops and top-level control flow statements in Starlark scripts. Added a regression test `TestWhileStatement` to ensure `while` loops function correctly.