### PR TITLE
feat(runtime): use schema defaults when a config entry is not set

### DIFF
--- a/examples/schema_hello_world/schema_hello_world.star
+++ b/examples/schema_hello_world/schema_hello_world.star
@@ -2,7 +2,7 @@ load("render.star", "render")
 load("schema.star", "schema")
 
 def main(config):
-    message = "Hello, %s!" % config.get("who", "World")
+    message = "Hello, %s!" % config.get("who")
 
     if config.bool("small"):
         msg = render.Text(message, font = "CG-pixel-3x5-mono")
@@ -22,6 +22,7 @@ def get_schema():
                 name = "Who?",
                 desc = "Who to say hello to.",
                 icon = "user",
+                default = "World",
             ),
             schema.Toggle(
                 id = "small",

--- a/runtime/applet.go
+++ b/runtime/applet.go
@@ -298,7 +298,7 @@ func ExtractRoots(val starlark.Value) ([]render.Root, error) {
 func (a *Applet) RunWithConfig(ctx context.Context, config map[string]any) (roots []render.Root, err error) {
 	var args starlark.Tuple
 	if a.mainFun.NumParams() > 0 {
-		starlarkConfig := AppletConfig(config)
+		starlarkConfig := NewAppletConfig(config, a.Schema)
 		args = starlark.Tuple{starlarkConfig}
 	}
 
@@ -328,7 +328,7 @@ func (app *Applet) CallSchemaHandler(ctx context.Context, handlerName, parameter
 	}
 
 	if handler.Function.NumParams() > 1 {
-		args = append(args, AppletConfig(config))
+		args = append(args, NewAppletConfig(config, app.Schema))
 	}
 
 	resultVal, err := app.Call(ctx, handler.Function, args...)


### PR DESCRIPTION
This changes app config to use the schema's default value. The schema default is only used if the second parameter is not passed to `config.get` or `config.bool`, otherwise the second parameter is used. Also note that schema handlers are not supported.

Fixes #328