### PR TITLE
perf(runtime): cache compiled applet code

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -116,9 +116,9 @@ func (o *apiOptions) renderHandler(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	buf, _, err := loader.RenderAppletFS(
+	buf, _, err := loader.RenderAppletRoot(
 		req.Context(),
-		o.root.FS(),
+		o.root,
 		r.Path,
 		r.Config,
 		loader.WithMeta(canvas.Metadata{

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -120,16 +120,20 @@ func checkRun(cmd *cobra.Command, args []string, opts *checkOptions) error {
 		}
 
 		// Check if an app can load.
-		if err = community.LoadApp(cmd.Context(), path); err != nil {
+		app, err := community.LoadApp(cmd.Context(), path)
+		if err != nil {
 			failure(path, fmt.Errorf("app failed to load: %w", err), "try `pixlet community load-app` and resolve any runtime issues")
 			return true
 		}
+		_ = app.Close()
 
 		// Ensure icons are valid.
-		if err = community.ValidateIcons(cmd.Context(), path); err != nil {
+		app, err = community.ValidateIcons(cmd.Context(), path)
+		if err != nil {
 			failure(path, fmt.Errorf("app has invalid icons: %w", err), "try `pixlet community list-icons` for the full list of valid icons")
 			return true
 		}
+		_ = app.Close()
 
 		// Check if app renders.
 		renderOpts := newRenderOptions()
@@ -199,14 +203,8 @@ func checkRun(cmd *cobra.Command, args []string, opts *checkOptions) error {
 			return true
 		}
 
-		if path == "." {
-			if abs, err := filepath.Abs(path); err == nil {
-				path = filepath.Base(abs)
-			}
-		}
-
 		// If we're here, the app and manifest are good to go!
-		success(path)
+		success(app.MainFile)
 		return false
 	}
 

--- a/cmd/community/loadapp.go
+++ b/cmd/community/loadapp.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
 	"github.com/tronbyt/pixlet/cmd/flags"
@@ -24,17 +23,13 @@ func NewLoadAppCmd() *cobra.Command {
 				path = args[0]
 			}
 
-			if err := LoadApp(cmd.Context(), path); err != nil {
+			app, err := LoadApp(cmd.Context(), path)
+			if err != nil {
 				return err
 			}
+			_ = app.Close()
 
-			if path == "." {
-				if abs, err := filepath.Abs(path); err == nil {
-					path = filepath.Base(abs)
-				}
-			}
-
-			slog.Info("App loaded successfully", "path", path)
+			slog.Info("App loaded successfully", "path", app.MainFile)
 			return nil
 		},
 		ValidArgsFunction: cobra.FixedCompletions([]string{"star"}, cobra.ShellCompDirectiveFilterFileExt),
@@ -42,10 +37,10 @@ func NewLoadAppCmd() *cobra.Command {
 	return cmd
 }
 
-func LoadApp(ctx context.Context, path string) error {
+func LoadApp(ctx context.Context, path string) (*runtime.Applet, error) {
 	cache, err := flags.NewCache().Load(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer cache.Close()
 
@@ -55,9 +50,8 @@ func LoadApp(ctx context.Context, path string) error {
 		runtime.WithCanvasMeta(flags.NewMeta().Metadata),
 	)
 	if err != nil {
-		return fmt.Errorf("failed to load applet: %w", err)
+		return nil, fmt.Errorf("failed to load applet: %w", err)
 	}
-	defer func() { _ = app.Close() }()
 
-	return nil
+	return app, nil
 }

--- a/cmd/community/validateicons.go
+++ b/cmd/community/validateicons.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
 	"github.com/tronbyt/pixlet/cmd/flags"
@@ -27,17 +26,13 @@ by our mobile app.`,
 				path = args[0]
 			}
 
-			if err := ValidateIcons(cmd.Context(), path); err != nil {
+			app, err := ValidateIcons(cmd.Context(), path)
+			if err != nil {
 				return err
 			}
+			_ = app.Close()
 
-			if path == "." {
-				if abs, err := filepath.Abs(path); err == nil {
-					path = filepath.Base(abs)
-				}
-			}
-
-			slog.Info("App icons are valid", "path", path)
+			slog.Info("App icons are valid", "path", app.MainFile)
 			return nil
 		},
 		ValidArgsFunction: cobra.FixedCompletions([]string{"star"}, cobra.ShellCompDirectiveFilterFileExt),
@@ -45,10 +40,10 @@ by our mobile app.`,
 	return cmd
 }
 
-func ValidateIcons(ctx context.Context, path string) error {
+func ValidateIcons(ctx context.Context, path string) (*runtime.Applet, error) {
 	cache, err := flags.NewCache().Load(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer cache.Close()
 
@@ -58,9 +53,8 @@ func ValidateIcons(ctx context.Context, path string) error {
 		runtime.WithCanvasMeta(flags.NewMeta().Metadata),
 	)
 	if err != nil {
-		return fmt.Errorf("failed to load applet: %w", err)
+		return nil, fmt.Errorf("failed to load applet: %w", err)
 	}
-	defer func() { _ = applet.Close() }()
 
 	if applet.Schema != nil {
 		for _, field := range applet.Schema.Fields {
@@ -69,10 +63,11 @@ func ValidateIcons(ctx context.Context, path string) error {
 			}
 
 			if _, ok := icons.IconsMap[field.Icon]; !ok {
-				return fmt.Errorf("app '%s' contains unknown icon: '%s'", applet.ID, field.Icon)
+				_ = applet.Close()
+				return nil, fmt.Errorf("app '%s' contains unknown icon: '%s'", applet.ID, field.Icon)
 			}
 		}
 	}
 
-	return nil
+	return applet, nil
 }

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -227,13 +227,19 @@ func renderRun(cmd *cobra.Command, args []string, opts *renderOptions) error {
 	}
 
 	if outPath == "-" {
-		_, err = os.Stdout.Write(buf)
+		if _, err := os.Stdout.Write(buf); err != nil {
+			return fmt.Errorf("writing to stdout: %w", err)
+		}
 	} else {
-		err = os.WriteFile(outPath, buf, 0644)
-	}
+		if err := os.WriteFile(outPath, buf, 0644); err != nil {
+			return fmt.Errorf("writing to file: %w", err)
+		}
 
-	if err != nil {
-		return fmt.Errorf("writing %s: %s", outPath, err)
+		if wd, err := os.Getwd(); err == nil {
+			if rel, err := filepath.Rel(wd, outPath); err == nil {
+				outPath = rel
+			}
+		}
 	}
 
 	opts.log.Info("Rendered image", "path", outPath)
@@ -250,6 +256,11 @@ func loadConfig(configPath string, args []string) (string, map[string]any, []str
 			starPath = args[0]
 			args = args[1:]
 		}
+	}
+
+	starPath, err := filepath.Abs(starPath)
+	if err != nil {
+		return "", nil, args, fmt.Errorf("failed to get absolute path for %s: %w", starPath, err)
 	}
 
 	config := map[string]any{}

--- a/runtime/applet.go
+++ b/runtime/applet.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path"
 	"path/filepath"
@@ -27,6 +28,7 @@ import (
 	starlibzip "github.com/qri-io/starlib/zipfile"
 	"github.com/tronbyt/pixlet/manifest"
 	"github.com/tronbyt/pixlet/render"
+	"github.com/tronbyt/pixlet/runtime/appletcache"
 	"github.com/tronbyt/pixlet/runtime/modules/animation_runtime"
 	modulecolor "github.com/tronbyt/pixlet/runtime/modules/color"
 	"github.com/tronbyt/pixlet/runtime/modules/encoding/yaml"
@@ -81,10 +83,11 @@ type Applet struct {
 	FS       fs.FS
 	MainFile string
 
-	loader       ModuleLoader
-	initializers []ThreadInitializer
-	loadedPaths  map[string]bool
-	closers      []io.Closer
+	compiledCache *appletcache.Cache
+	loader        ModuleLoader
+	initializers  []ThreadInitializer
+	loadedPaths   map[string]bool
+	closers       []io.Closer
 
 	mainFun    *starlark.Function
 	schemaFile string
@@ -177,6 +180,14 @@ func WithTests(t testing.TB) AppletOption {
 	}
 }
 
+func WithCompiledCache(cache *appletcache.Cache) AppletOption {
+	return func(a *Applet) error {
+		a.compiledCache = cache
+		a.closers = append(a.closers, cache)
+		return nil
+	}
+}
+
 func NewApplet(ctx context.Context, id string, src []byte, opts ...AppletOption) (*Applet, error) {
 	fn := id
 	if !strings.HasSuffix(fn, ".star") {
@@ -229,6 +240,21 @@ func NewAppletFromFS(ctx context.Context, fsys fs.FS, id string, opts ...AppletO
 	return a, nil
 }
 
+func NewAppletFromRoot(ctx context.Context, root *os.Root, id string, opts ...AppletOption) (*Applet, error) {
+	if compiledCache, err := appletcache.New(root); err == nil {
+		opts = append(opts, WithCompiledCache(compiledCache))
+	} else if !errors.Is(err, appletcache.ErrDisabled) {
+		slog.Warn("Failed to set up compiled cache", "error", err)
+	}
+
+	a, err := NewAppletFromFS(ctx, root.FS(), id, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return a, nil
+}
+
 var ErrStarSuffix = fmt.Errorf("script file must have suffix .star")
 
 func NewAppletFromPath(ctx context.Context, path string, opts ...AppletOption) (*Applet, error) {
@@ -251,7 +277,7 @@ func NewAppletFromPath(ctx context.Context, path string, opts ...AppletOption) (
 		return nil, fmt.Errorf("failed to open root for %s: %w", path, err)
 	}
 
-	a, err := NewAppletFromFS(ctx, root.FS(), filepath.Base(path), opts...)
+	a, err := NewAppletFromRoot(ctx, root, filepath.Base(path), opts...)
 	if err != nil {
 		_ = root.Close()
 		return nil, err
@@ -556,11 +582,6 @@ func (a *Applet) ensureLoaded(ctx context.Context, fsys fs.FS, pathToLoad string
 		a.loadedPaths[pathToLoad] = true
 	}
 
-	src, err := fs.ReadFile(fsys, pathToLoad)
-	if err != nil {
-		return fmt.Errorf("reading %s: %v", pathToLoad, err)
-	}
-
 	predeclared := starlark.StringDict{
 		"struct": starlark.NewBuiltin("struct", starlarkstruct.Make),
 	}
@@ -594,21 +615,66 @@ func (a *Applet) ensureLoaded(ctx context.Context, fsys fs.FS, pathToLoad string
 
 	switch path.Ext(pathToLoad) {
 	case ".star":
-		globals, err := starlark.ExecFileOptions(
-			&syntax.FileOptions{
-				Set:             true,
-				Recursion:       true,
-				While:           true,
-				TopLevelControl: true,
-			},
-			thread,
-			path.Join(a.ID, pathToLoad),
-			src,
-			predeclared,
-		)
+		var mod *starlark.Program
+
+		src, err := fsys.Open(pathToLoad)
 		if err != nil {
-			return fmt.Errorf("starlark.ExecFile: %v", err)
+			return fmt.Errorf("reading %s: %v", pathToLoad, err)
 		}
+		defer func() { _ = src.Close() }()
+
+		if a.compiledCache != nil {
+			if r, ok, err := a.compiledCache.NewReader(ctx, a.ID, pathToLoad, src); err == nil {
+				if ok {
+					if mod, err = starlark.CompiledProgram(r); err != nil {
+						slog.Warn("Failed to load compiled program", "error", err)
+					}
+					_ = r.Close()
+				}
+			} else {
+				slog.Warn("Failed to load compiled program from cache", "error", err)
+			}
+		}
+
+		if mod == nil {
+			srcBytes, err := fs.ReadFile(fsys, pathToLoad)
+			if err != nil {
+				return fmt.Errorf("reading %s: %v", pathToLoad, err)
+			}
+
+			_, mod, err = starlark.SourceProgramOptions(
+				&syntax.FileOptions{
+					Set:             true,
+					Recursion:       true,
+					While:           true,
+					TopLevelControl: true,
+				},
+				path.Join(a.ID, pathToLoad),
+				srcBytes,
+				predeclared.Has,
+			)
+			if err != nil {
+				return fmt.Errorf("starlark.SourceProgram: %v", err)
+			}
+
+			if a.compiledCache != nil {
+				if w, err := a.compiledCache.NewWriter(ctx, a.ID, pathToLoad, src); err == nil {
+					if err := mod.Write(w); err != nil {
+						slog.Warn("Failed to write compiled program cache", "error", err)
+					}
+					_ = w.Close()
+				} else {
+					slog.Warn("Failed to create compiled program cache", "error", err)
+				}
+			}
+		}
+
+		globals, err := mod.Init(thread, predeclared)
+		if err != nil {
+			return fmt.Errorf("initializing module: %v", err)
+		}
+
+		globals.Freeze()
 		a.Globals[pathToLoad] = globals
 
 		// if the file is in the root directory, check for the main function

--- a/runtime/appletcache/appletcache.go
+++ b/runtime/appletcache/appletcache.go
@@ -1,0 +1,178 @@
+package appletcache
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path"
+	"strconv"
+
+	"go.uber.org/atomic"
+)
+
+const (
+	enabledEnv = "PIXLET_APPLET_CACHE_ENABLED"
+	dirEnv     = "PIXLET_APPLET_CACHE_DIR"
+)
+
+var (
+	Enabled = atomic.NewBool(true)
+	Dir     = atomic.String{}
+)
+
+func init() { //nolint:gochecknoinits
+	if env := os.Getenv(enabledEnv); env != "" {
+		if val, err := strconv.ParseBool(env); err == nil {
+			Enabled.Store(val)
+		} else {
+			slog.Warn(enabledEnv+" is invalid; using default.", "error", err)
+		}
+	}
+
+	if env := os.Getenv(dirEnv); env != "" {
+		Dir.Store(env)
+	}
+}
+
+const starCacheDir = ".starcache"
+
+var ErrDisabled = errors.New("applet cache is disabled")
+
+func New(root *os.Root) (*Cache, error) {
+	if !Enabled.Load() {
+		return nil, ErrDisabled
+	}
+
+	cache := &Cache{}
+	if dir := Dir.Load(); dir != "" {
+		cache.nest = true
+
+		if err := os.Mkdir(dir, 0755); err != nil && !errors.Is(err, fs.ErrExist) {
+			return nil, fmt.Errorf("failed to create starcache dir: %w", err)
+		}
+
+		var err error
+		if cache.root, err = os.OpenRoot(dir); err != nil {
+			return nil, fmt.Errorf("failed to open cache root: %w", err)
+		}
+	} else {
+		if err := root.Mkdir(starCacheDir, 0755); err != nil && !errors.Is(err, fs.ErrExist) {
+			return nil, fmt.Errorf("failed to create starcache dir: %w", err)
+		}
+
+		var err error
+		if cache.root, err = root.OpenRoot(starCacheDir); err != nil {
+			return nil, fmt.Errorf("failed to open starcache root: %w", err)
+		}
+
+		if err := cache.root.WriteFile(".gitignore", []byte("*\n"), 0644); err != nil && !errors.Is(err, fs.ErrExist) {
+			_ = cache.root.Close()
+			return nil, fmt.Errorf("failed to write starcache .gitignore: %w", err)
+		}
+	}
+
+	return cache, nil
+}
+
+type Cache struct {
+	root *os.Root
+	nest bool
+}
+
+type Header struct {
+	Size    int64
+	ModTime int64
+}
+
+func (c Cache) NewWriter(_ context.Context, id, key string, sourceFile fs.File) (io.WriteCloser, error) {
+	stat, err := sourceFile.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stating source file: %w", err)
+	}
+
+	cachePath := c.cachePath(id, key)
+
+	if dir := path.Dir(cachePath); dir != "." {
+		if err := c.root.Mkdir(id, 0755); err != nil && !errors.Is(err, fs.ErrExist) {
+			return nil, fmt.Errorf("failed to create cache dir: %w", err)
+		}
+	}
+
+	f, err := c.root.Create(cachePath)
+	if err != nil {
+		return nil, fmt.Errorf("creating cache file: %w", err)
+	}
+	var success bool
+	defer func() {
+		if !success {
+			_ = f.Close()
+			_ = c.root.Remove(cachePath)
+		}
+	}()
+
+	data := Header{
+		Size:    stat.Size(),
+		ModTime: stat.ModTime().UnixNano(),
+	}
+
+	if err := binary.Write(f, binary.LittleEndian, &data); err != nil {
+		return nil, fmt.Errorf("writing cache file: %w", err)
+	}
+
+	success = true
+	return f, nil
+}
+
+func (c Cache) NewReader(_ context.Context, id, key string, sourceFile fs.File) (io.ReadCloser, bool, error) {
+	sourceStat, err := sourceFile.Stat()
+	if err != nil {
+		return nil, false, fmt.Errorf("stating source file: %w", err)
+	}
+
+	cacheFile, err := c.root.Open(c.cachePath(id, key))
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("opening cache file: %w", err)
+	}
+	var success bool
+	defer func() {
+		if !success {
+			_ = cacheFile.Close()
+		}
+	}()
+
+	var data Header
+
+	if err := binary.Read(cacheFile, binary.LittleEndian, &data); err != nil {
+		return nil, false, fmt.Errorf("reading cache file: %w", err)
+	}
+
+	if data.Size != sourceStat.Size() || data.ModTime != sourceStat.ModTime().UnixNano() {
+		return nil, false, nil
+	}
+
+	success = true
+	return cacheFile, true, nil
+}
+
+func (c Cache) Close() error {
+	if c.root != nil {
+		return c.root.Close()
+	}
+	return nil
+}
+
+func (c Cache) cachePath(id, key string) string {
+	key += ".bin"
+	if c.nest {
+		return path.Join(id, key)
+	}
+	return key
+}

--- a/server/loader/loader.go
+++ b/server/loader/loader.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -278,12 +277,13 @@ func (l *Loader) loadApplet() error {
 		runtime.WithLanguage(l.conf.Language),
 	}
 
-	app, err := runtime.NewAppletFromFS(context.Background(), l.root.FS(), l.conf.Path, opts...)
+	app, err := runtime.NewAppletFromRoot(context.Background(), l.root, l.conf.Path, opts...)
 	l.markInitialLoadComplete()
 	if err != nil {
 		return err
 	}
 
+	_ = l.applet.Close()
 	l.applet = *app
 	return nil
 }
@@ -323,16 +323,26 @@ func (l *Loader) Meta() canvas.Metadata {
 }
 
 func RenderApplet(ctx context.Context, path string, config map[string]any, options ...Option) ([]byte, []string, error) {
-	root, err := os.OpenRoot(filepath.Dir(path))
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to stat file: %w", err)
+	}
+
+	dir := path
+	if !info.IsDir() {
+		dir = filepath.Dir(path)
+	}
+
+	root, err := os.OpenRoot(dir)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to open root: %w", err)
 	}
 	defer func() { _ = root.Close() }()
 
-	return RenderAppletFS(ctx, root.FS(), filepath.Base(path), config, options...)
+	return RenderAppletRoot(ctx, root, filepath.Base(path), config, options...)
 }
 
-func RenderAppletFS(ctx context.Context, fsys fs.FS, path string, config map[string]any, options ...Option) ([]byte, []string, error) {
+func RenderAppletRoot(ctx context.Context, root *os.Root, path string, config map[string]any, options ...Option) ([]byte, []string, error) {
 	conf := NewRenderConfig(path, config, options...)
 
 	opts := []runtime.AppletOption{
@@ -349,7 +359,7 @@ func RenderAppletFS(ctx context.Context, fsys fs.FS, path string, config map[str
 		}))
 	}
 
-	applet, err := runtime.NewAppletFromFS(ctx, fsys, path, opts...)
+	applet, err := runtime.NewAppletFromRoot(ctx, root, path, opts...)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -64,12 +64,7 @@ func NewServer(
 		return nil, err
 	}
 
-	title := filepath.Base(path)
-	if title == "." {
-		if mainFile := l.GetMainFile(); mainFile != "" {
-			title = mainFile
-		}
-	}
+	title := l.GetMainFile()
 
 	b, err := browser.NewBrowser(host, port, servePath, title, watch, updatesChan, l, openBrowser)
 	if err != nil {


### PR DESCRIPTION
This PR optimizes the rendering pipeline by caching the compiled Starlark programs to disk. When a program is rendered, a hidden directory `.starcache` will be created (similarly to how Python creates `__pycache__`), and compiled programs will be stored inside. A `.gitignore` file will be placed inside which ignores all files in the dir.

If the source file's timestamp is updated or the source file changes in size, the cache will be invalidated.

In my testing on a MacBook Pro M1, apps generally take anywhere between a few ms up to 40ms to be parsed. Once the compiled program is cached, it almost always takes under 1ms.

The PR also adds 2 new environment variables:
- `PIXLET_APPLET_CACHE_ENABLED`: Set to `false` to completely disable applet caching
- `PIXLET_APPLET_CACHE_DIR`: Allows to set a global cache dir

This PR contains some temporary logs to compare render times. These will be removed before the PR is merged.