### PR TITLE
Document loading asset from files

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -79,6 +79,49 @@ def get_counter():
 ...
 ```
 
+## Pixlet module: File
+
+The file module lets you load files from your app's directory as
+assets. Unlike other modules, you don't load a `.star` file. Instead,
+you `load` the asset path directly and alias the `"file"` identifier
+to a variable of your choosing:
+
+```starlark
+load("my_image.png", img = "file")
+```
+
+This gives you a `File` object bound to `img`. Note that the alias
+(`img = "file"`) is required since Starlark's `load` statement only
+imports named identifiers - there's no default export to grab.
+
+### File object
+
+| Attribute / Method | Description |
+| --- | --- |
+| `path` | The path of the file as a string. |
+| `readall(mode?)` | Reads the entire file. `mode` can be `"r"` or `"rt"` for text (default), or `"rb"` for binary data. |
+
+Example:
+
+```starlark
+load("render.star", "render")
+load("icon.png", icon_file = "file")
+load("message.txt", message_file = "file")
+
+ICON = icon_file.readall("rb")
+MESSAGE = message_file.readall()
+
+def main():
+    return render.Root(
+        child = render.Row(
+            children = [
+                render.Image(src=ICON),
+                render.Text(MESSAGE),
+            ],
+        ),
+    )
+```
+
 ## Pixlet module: HMAC
 
 This module implements the HMAC algorithm as described by [RFC 2104](https://datatracker.ietf.org/doc/html/rfc2104.html).

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -148,8 +148,8 @@ too shabby!
 
 ### Tip: loading assets from files
 
-Instead of embedding the icon as base64, we can place
-`tutorial_bitcoin.png` next to our script and load it directly:
+Instead of embedding the icon as base64, we can load it directly from
+our app's directory:
 
 ```starlark
 # Load Bitcoin icon from file

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -146,6 +146,21 @@ This clearly leaves something to be desired as far as layout is
 concerned, but the individual elements (the icon and the price) aren't
 too shabby!
 
+### Tip: loading assets from files
+
+Instead of embedding the icon as base64, we can place
+`tutorial_bitcoin.png` next to our script and load it directly:
+
+```starlark
+# Load Bitcoin icon from file
+load("img/tutorial_bitcoin.png", btc_icon_file = "file")
+
+BTC_ICON = btc_icon_file.readall("rb")
+```
+
+The rest of this tutorial sticks with the base64 approach for
+simplicity.
+
 ## Beautification
 
 By default, `Row` will pack its children as closely together as it


### PR DESCRIPTION
This adds some docs for how to load assets from files instead of using base64.

I took the scenic route to discover this pattern: I implemented it from scratch myself (https://github.com/liesen/pixlet/tree/file-module) before realising the file module already existed but wasn't documented. Hopefully this saves someone else the same detour.