### PR TITLE
docs(readme): use new docs URL; change Tidbyt to Tronbyt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,21 @@
 # Pixlet
-[![Docs](https://img.shields.io/badge/docs-tidbyt.dev-blue?style=flat-square)](https://tidbyt.dev)
-[![Build & test](https://img.shields.io/github/actions/workflow/status/Tronbyt/pixlet/main.yml?branch=main&style=flat-square)](https://github.com/tronbyt/pixlet/actions)
-[![Discourse](https://img.shields.io/discourse/status?server=https%3A%2F%2Fdiscuss.tidbyt.com&style=flat-square)](https://discuss.tidbyt.com/)
-[![Discord Server](https://img.shields.io/discord/928484660785336380?style=flat-square)](https://discord.gg/r45MXG4kZc)
-[![GoDoc](https://godoc.org/github.com/tidbyt/pixlet/runtime?status.svg)](https://godoc.org/github.com/tidbyt/pixlet/runtime)
+[![Docs](https://img.shields.io/badge/docs-tronbyt.com-blue?style=flat-square)](https://tronbyt.com)
+[![Build & test](https://img.shields.io/github/actions/workflow/status/tronbyt/pixlet/main.yml?branch=main&style=flat-square)](https://github.com/tronbyt/pixlet/actions)
+[![Discord Server](https://img.shields.io/discord/1343943766976888914?style=flat-square)](https://tronbyt.com/discord/)
+[![GoDoc](https://godoc.org/github.com/tronbyt/pixlet/runtime?status.svg)](https://godoc.org/github.com/tronbyt/pixlet/runtime)
 
 Pixlet is an app runtime and UX toolkit for highly-constrained displays.
-We use Pixlet to develop applets for [Tidbyt](https://tidbyt.com/), which has
+We use Pixlet to develop applets for [Tronbyt](https://github.com/tronbyt/server), which has
 a 64x32 RGB LED matrix display:
 
-[![Example of a Tidbyt](docs/img/tidbyt_1.png)](https://tidbyt.com)
+[![Example of a Tronbyt](docs/img/tidbyt_1.png)](https://tronbyt.com)
 
 Apps developed with Pixlet can be served in a browser, rendered as WebP or
-GIF animations, or pushed to a physical Tidbyt device.
+GIF animations, or pushed to a physical Tronbyt device.
 
 ## Documentation
 
-> Hey! We have a new docs site! Check it out at [tidbyt.dev](https://tidbyt.dev). We'll be updating this repo in the coming weeks.
+> Hey! We have a new docs site! Check it out at [tronbyt.com](https://tronbyt.com).
 
 - [Getting started](#getting-started)
 - [How it works](#how-it-works)
@@ -60,7 +59,7 @@ def main():
 Render and serve it with:
 
 ```console
-curl https://raw.githubusercontent.com/tidbyt/pixlet/main/examples/hello_world/hello_world.star | \
+curl https://raw.githubusercontent.com/tronbyt/pixlet/main/examples/hello_world/hello_world.star | \
   pixlet serve /dev/stdin
 ```
 
@@ -79,7 +78,7 @@ _Widgets_ to describe how the data should be presented visually.
 
 The Pixlet CLI runs these scripts and renders the result as a WebP
 or GIF animation. You can view the animation in your browser, save
-it, or even push it to a Tidbyt device with `pixlet push`.
+it, or even push it to a Tronbyt device with `pixlet push`.
 
 ### Example: A Clock App
 
@@ -128,34 +127,34 @@ here is a Bitcoin price tracker:
 Read the [in-depth tutorial](docs/tutorial.md) to learn how to
 make an applet like this.
 
-## Push to a Tidbyt
+## Push to a Tronbyt
 
-If you have a Tidbyt, `pixlet` can push apps directly to it. For example,
-to show the Bitcoin tracker on your Tidbyt:
+If you have a Tronbyt, `pixlet` can push apps directly to it. For example,
+to show the Bitcoin tracker on your Tronbyt:
 
 ```console
 # render the bitcoin example
 pixlet render examples/bitcoin/bitcoin.star
 
-# login to your Tidbyt account
+# login to your Tronbyt account
 pixlet login
 
-# list available Tidbyt devices
+# list available Tronbyt devices
 pixlet devices
 
-# push to your favorite Tidbyt
+# push to your favorite Tronbyt
 pixlet push <YOUR DEVICE ID> examples/bitcoin/bitcoin.webp
 ```
 
 To get the ID for a device, run `pixlet devices`. Alternatively, you can
-open the settings for the device in the Tidbyt app on your phone, and tap **Get API key**.
+open the settings for the device in the Tronbyt app on your phone, and tap **Get API key**.
 
-If all goes well, you should see the Bitcoin tracker appear on your Tidbyt:
+If all goes well, you should see the Bitcoin tracker appear on your Tronbyt:
 
 ![](docs/img/tidbyt_2.jpg)
 
 ## Push as an Installation
-Pushing an applet to your Tidbyt without an installation ID simply displays your applet one time. If you would like your applet to continously display as part of the rotation, add an installation ID to the push command:
+Pushing an applet to your Tronbyt without an installation ID simply displays your applet one time. If you would like your applet to continously display as part of the rotation, add an installation ID to the push command:
 
 ```console
 pixlet render examples/bitcoin/bitcoin.star
@@ -166,4 +165,4 @@ For example, if we set the `installationID` to "Bitcoin", it would appear in the
 
 ![](docs/img/mobile_1.jpg)
 
-**Note:** `pixlet render` executes your Starlark code and generates a WebP image. `pixlet push` deploys the generated WebP image to your device. You'll need to repeat this process if you want to keep the app updated. You can also create [Community Apps](https://github.com/tidbyt/community) that run on Tidbyt’s servers and update automatically.
+**Note:** `pixlet render` executes your Starlark code and generates a WebP image. `pixlet push` deploys the generated WebP image to your device. You'll need to repeat this process if you want to keep the app updated. You can also create [Community Apps](https://github.com/tronbyt/apps) that are downloaded to all Tronbyt instances, or create a personal apps repository.


### PR DESCRIPTION
Adds links to https://tronbyt.com, updates the Discord link to our server, replaces any other Tidbyt references in the README.