### PR TITLE
feat(render): support passing bytes to render.Image

### DIFF
--- a/bundle/write.go
+++ b/bundle/write.go
@@ -69,7 +69,7 @@ func (ab *AppBundle) WriteBundle(ctx context.Context, out io.Writer, opts ...Wri
 		// since it could contain a lot of extraneous files. instead, run the
 		// applet and interrogate it for the files it needs to include in the
 		// bundle.
-		app, err := runtime.NewAppletFromFS(ctx, ab.Source, ab.Manifest.ID ,runtime.WithPrintDisabled())
+		app, err := runtime.NewAppletFromFS(ctx, ab.Source, ab.Manifest.ID, runtime.WithPrintDisabled())
 		if err != nil {
 			return fmt.Errorf("loading applet for bundling: %w", err)
 		}

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -238,7 +238,7 @@ the `delay` attribute.
 #### Attributes
 | Name | Type | Description | Required |
 | --- | --- | --- | --- |
-| `src` | `str` | Binary image data or SVG text | **Y** |
+| `src` | `str / bytes` | Binary image data or SVG text | **Y** |
 | `width` | `int` | Scale image to this width | N |
 | `height` | `int` | Scale image to this height | N |
 | `delay` | `int` | (Read-only) Frame delay in ms, for animated GIFs | N |

--- a/render/image.go
+++ b/render/image.go
@@ -155,16 +155,22 @@ func (p *Image) InitFromSVG(data []byte) error {
 	return nil
 }
 
+func (p *Image) parse() error {
+	if err := p.InitFromWebP(p.Src); err == nil {
+		return nil
+	}
+	if err := p.InitFromGIF(p.Src); err == nil {
+		return nil
+	}
+	if err := p.InitFromSVG(p.Src); err == nil {
+		return nil
+	}
+	return p.InitFromImage(p.Src)
+}
+
 func (p *Image) Init(*starlark.Thread) error {
-	var err error
-	if err = p.InitFromWebP(p.Src); err != nil {
-		if err = p.InitFromGIF(p.Src); err != nil {
-			if err = p.InitFromSVG(p.Src); err != nil {
-				if err = p.InitFromImage(p.Src); err != nil {
-					return err
-				}
-			}
-		}
+	if err := p.parse(); err != nil {
+		return err
 	}
 
 	w := p.imgs[0].Bounds().Dx()

--- a/render/image.go
+++ b/render/image.go
@@ -31,7 +31,7 @@ import (
 // the `delay` attribute.
 type Image struct {
 	// Binary image data or SVG text
-	Src string `starlark:"src,required"`
+	Src []byte `starlark:"src,required"`
 	// Scale image to this width
 	Width int
 	// Scale image to this height
@@ -156,19 +156,15 @@ func (p *Image) InitFromSVG(data []byte) error {
 }
 
 func (p *Image) Init(*starlark.Thread) error {
-	err := p.InitFromWebP([]byte(p.Src))
-	if err != nil {
-		err = p.InitFromGIF([]byte(p.Src))
-		if err != nil {
-			err = p.InitFromSVG([]byte(p.Src))
-			if err != nil {
-				err = p.InitFromImage([]byte(p.Src))
+	var err error
+	if err = p.InitFromWebP(p.Src); err != nil {
+		if err = p.InitFromGIF(p.Src); err != nil {
+			if err = p.InitFromSVG(p.Src); err != nil {
+				if err = p.InitFromImage(p.Src); err != nil {
+					return err
+				}
 			}
 		}
-	}
-
-	if err != nil {
-		return err
 	}
 
 	w := p.imgs[0].Bounds().Dx()

--- a/render/image_test.go
+++ b/render/image_test.go
@@ -15,7 +15,7 @@ const testPNG = "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAMCAYAAABbayygAAAAOUlEQVQoU2P8z8D
 
 func TestImage(t *testing.T) {
 	raw, _ := base64.StdEncoding.DecodeString(testPNG)
-	img := &Image{Src: string(raw)}
+	img := &Image{Src: raw}
 	require.NoError(t, img.Init(nil))
 
 	// Size of Image is independent of bounds
@@ -62,7 +62,7 @@ func TestImage(t *testing.T) {
 // individual pixels.
 func TestImageScale(t *testing.T) {
 	raw, _ := base64.StdEncoding.DecodeString(testPNG)
-	img := &Image{Src: string(raw), Width: 5, Height: 6}
+	img := &Image{Src: raw, Width: 5, Height: 6}
 	require.NoError(t, img.Init(nil))
 
 	w, h := img.Size()
@@ -78,7 +78,7 @@ func TestImageScale(t *testing.T) {
 // but don't bother checking individual pixels.
 func TestImageScaleAspectRatioWidth(t *testing.T) {
 	raw, _ := base64.StdEncoding.DecodeString(testPNG)
-	img := &Image{Src: string(raw), Width: 5}
+	img := &Image{Src: raw, Width: 5}
 	require.NoError(t, img.Init(nil))
 
 	w, h := img.Size()
@@ -94,7 +94,7 @@ func TestImageScaleAspectRatioWidth(t *testing.T) {
 // but don't bother checking individual pixels.
 func TestImageScaleAspectRatioHeight(t *testing.T) {
 	raw, _ := base64.StdEncoding.DecodeString(testPNG)
-	img := &Image{Src: string(raw), Height: 6}
+	img := &Image{Src: raw, Height: 6}
 	require.NoError(t, img.Init(nil))
 
 	w, h := img.Size()
@@ -121,7 +121,7 @@ func TestImageAnimatedGif(t *testing.T) {
 	// GIF has no disposal method set, and a delay of 1230 ms
 
 	raw, _ := base64.StdEncoding.DecodeString(testGIF)
-	img := &Image{Src: string(raw)}
+	img := &Image{Src: raw}
 	require.NoError(t, img.Init(nil))
 
 	w, h := img.Size()
@@ -178,7 +178,7 @@ func TestImageAnimatedGif(t *testing.T) {
 
 func TestImageAnimatedGifWithHoldFrames(t *testing.T) {
 	raw, _ := base64.StdEncoding.DecodeString(testGIF)
-	img := &Image{Src: string(raw), HoldFrames: 2}
+	img := &Image{Src: raw, HoldFrames: 2}
 	require.NoError(t, img.Init(nil))
 
 	assert.Equal(t, 8, img.FrameCount(image.Rect(0, 0, 0, 0)))
@@ -192,11 +192,11 @@ func TestImageAnimatedGifWithHoldFrames(t *testing.T) {
 
 func TestImageSVG(t *testing.T) {
 	// Simple SVG: 10x10, left half red, right half transparent (default)
-	svg := `
+	svg := []byte(`
 <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">
   <rect x="0" y="0" width="5" height="10" fill="#FF0000"/>
 </svg>
-`
+`)
 	img := &Image{Src: svg}
 	err := img.Init(nil)
 	require.NoError(t, err)

--- a/runtime/gen/attr/bytes.tmpl
+++ b/runtime/gen/attr/bytes.tmpl
@@ -1,0 +1,11 @@
+{{ if not .IsReadOnly }}
+w.{{ .StarlarkGoName }} = {{ .StarlarkName }}
+switch {{ .StarlarkName }} := {{ .StarlarkName }}.(type) {
+case starlark.String:
+    w.{{ .GoPath }} = []byte({{ .StarlarkName }})
+case starlark.Bytes:
+    w.{{ .GoPath }} = []byte({{ .StarlarkName }})
+default:
+    return nil, fmt.Errorf("got %s, want string or bytes", {{ .StarlarkName }}.Type())
+}
+{{- end }}

--- a/runtime/gen/config.go
+++ b/runtime/gen/config.go
@@ -109,6 +109,12 @@ var TypeMap = map[reflect.Type]Type{
 		DocType:      "str",
 		TemplatePath: "attr/string.tmpl",
 	},
+	reflect.TypeFor[[]byte](): {
+		GoType:        "starlark.Value",
+		DocType:       "str / bytes",
+		TemplatePath:  "attr/bytes.tmpl",
+		GenerateField: true,
+	},
 	reflect.TypeFor[int](): {
 		GoType:       "starlark.Int",
 		DocType:      "int",

--- a/runtime/modules/file/file.go
+++ b/runtime/modules/file/file.go
@@ -35,12 +35,13 @@ func (f *File) readall(_ *starlark.Thread, b *starlark.Builtin, args starlark.Tu
 		return nil, err
 	}
 
+	str := unsafe.String(unsafe.SliceData(bs), len(bs))
+
 	switch mode {
 	case ModeReadText:
-		str := unsafe.String(unsafe.SliceData(bs), len(bs))
 		return starlark.String(str), nil
 	case ModeReadBinary:
-		return starlark.Bytes(bs), nil
+		return starlark.Bytes(str), nil
 	default:
 		return nil, ErrUnsupportedMode
 	}

--- a/runtime/modules/render_runtime/generated.go
+++ b/runtime/modules/render_runtime/generated.go
@@ -963,6 +963,8 @@ func emojiFrameCount(
 
 type Image struct {
 	render.Image
+
+	starlarkSrc starlark.Value
 }
 
 func newImage(
@@ -972,7 +974,7 @@ func newImage(
 	kwargs []starlark.Tuple,
 ) (starlark.Value, error) {
 	var (
-		src    starlark.String
+		src    starlark.Value
 		width  starlark.Int
 		height starlark.Int
 
@@ -992,7 +994,15 @@ func newImage(
 
 	w := &Image{}
 
-	w.Src = src.GoString()
+	w.starlarkSrc = src
+	switch src := src.(type) {
+	case starlark.String:
+		w.Src = []byte(src)
+	case starlark.Bytes:
+		w.Src = []byte(src)
+	default:
+		return nil, fmt.Errorf("got %s, want string or bytes", src.Type())
+	}
 
 	if val, err := starlarkutil.AsInt[int64](width); err == nil {
 		w.Width = int(val)
@@ -1036,7 +1046,7 @@ func (w *Image) AttrNames() []string {
 func (w *Image) Attr(name string) (starlark.Value, error) {
 	switch name {
 	case "src":
-		return starlark.String(w.Src), nil
+		return w.starlarkSrc, nil
 	case "width":
 		return starlark.MakeInt(int(w.Width)), nil
 	case "height":

--- a/schema/notification_test.go
+++ b/schema/notification_test.go
@@ -51,7 +51,7 @@ def main():
 		"sound.mp3":         &fstest.MapFile{Data: []byte("sound data")},
 		"notification.star": &fstest.MapFile{Data: []byte(source)},
 	}
-	app, err := runtime.NewAppletFromFS(t.Context(), vfs, "sound" ,runtime.WithTests(t))
+	app, err := runtime.NewAppletFromFS(t.Context(), vfs, "sound", runtime.WithTests(t))
 	require.NoError(t, err)
 
 	screens, err := app.Run(t.Context())


### PR DESCRIPTION
Adds support for passing `starlark.Bytes` to `render.Image`.

Also fixes a small issue I caught when loading files in binary mode. I previously optimized   `readall` in `r` mode to convert the `[]byte` to `string` without a copy using `unsafe`. Since `starlark.Bytes` is also a `string`, the `rb` mode needs this same optimization.

Also fixes an unrelated formatting issue I caused in a previous PR while performing a find and replace.

Fixes #430