### PR TITLE
chore: improve error messages

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -211,7 +211,7 @@ func checkRun(cmd *cobra.Command, args []string, opts *checkOptions) error {
 	for _, path := range args {
 		info, err := os.Stat(path)
 		if err != nil {
-			return fmt.Errorf("failed to stat %s: %w", path, err)
+			return fmt.Errorf("stat %s: %w", path, err)
 		}
 
 		if opts.recursive && info.IsDir() {
@@ -236,7 +236,7 @@ func checkRun(cmd *cobra.Command, args []string, opts *checkOptions) error {
 				return nil
 			})
 			if err != nil {
-				return fmt.Errorf("failed to walk %s: %w", path, err)
+				return fmt.Errorf("walking %s: %w", path, err)
 			}
 		} else {
 			if checkApp(path) {

--- a/cmd/community/createmanifest.go
+++ b/cmd/community/createmanifest.go
@@ -32,7 +32,7 @@ func CreateManifest(_ *cobra.Command, args []string) error {
 	if filepath.Base(path) != manifest.ManifestFileName {
 		info, err := os.Stat(path)
 		if err != nil {
-			return fmt.Errorf("failed to stat %s: %w", path, err)
+			return fmt.Errorf("stat %s: %w", path, err)
 		}
 
 		if !info.IsDir() {
@@ -50,7 +50,7 @@ func CreateManifest(_ *cobra.Command, args []string) error {
 
 	m, err := ManifestPrompt()
 	if err != nil {
-		return fmt.Errorf("failed prompt: %w", err)
+		return fmt.Errorf("prompting: %w", err)
 	}
 
 	err = m.WriteManifest(f)

--- a/cmd/community/loadapp.go
+++ b/cmd/community/loadapp.go
@@ -50,7 +50,7 @@ func LoadApp(ctx context.Context, path string) (*runtime.Applet, error) {
 		runtime.WithCanvasMeta(flags.NewMeta().Metadata),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load applet: %w", err)
+		return nil, fmt.Errorf("loading applet: %w", err)
 	}
 
 	return app, nil

--- a/cmd/community/validateicons.go
+++ b/cmd/community/validateicons.go
@@ -53,7 +53,7 @@ func ValidateIcons(ctx context.Context, path string) (*runtime.Applet, error) {
 		runtime.WithCanvasMeta(flags.NewMeta().Metadata),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load applet: %w", err)
+		return nil, fmt.Errorf("loading applet: %w", err)
 	}
 
 	if applet.Schema != nil {

--- a/cmd/community/validatemanifest.go
+++ b/cmd/community/validatemanifest.go
@@ -27,7 +27,7 @@ validating the contents of each field.`,
 			if filepath.Base(path) != manifest.ManifestFileName {
 				info, err := os.Stat(path)
 				if err != nil {
-					return fmt.Errorf("failed to stat %s: %w", path, err)
+					return fmt.Errorf("stat %s: %w", path, err)
 				}
 
 				if !info.IsDir() {

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -126,23 +126,23 @@ func ProfileApp(ctx context.Context, path string, config map[string]any, meta ca
 		runtime.WithCanvasMeta(meta),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load applet: %w", err)
+		return nil, fmt.Errorf("loading applet: %w", err)
 	}
 	defer func() { _ = applet.Close() }()
 
 	buf := new(bytes.Buffer)
 	if err = starlark.StartProfile(buf); err != nil {
-		return nil, fmt.Errorf("error starting profiler: %w", err)
+		return nil, fmt.Errorf("starting profiler: %w", err)
 	}
 
 	_, err = applet.RunWithConfig(ctx, config)
 	if err != nil {
 		_ = starlark.StopProfile()
-		return nil, fmt.Errorf("error running script: %w", err)
+		return nil, fmt.Errorf("running script: %w", err)
 	}
 
 	if err = starlark.StopProfile(); err != nil {
-		return nil, fmt.Errorf("error stopping profiler: %w", err)
+		return nil, fmt.Errorf("stopping profiler: %w", err)
 	}
 
 	profile, err := pprof_profile.ParseData(buf.Bytes())

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -72,7 +72,7 @@ func pushRun(cmd *cobra.Command, args []string, opts *pushOptions) error {
 	} else {
 		f, err := os.Open(image)
 		if err != nil {
-			return fmt.Errorf("failed to read file %s: %w", image, err)
+			return fmt.Errorf("opening %s: %w", image, err)
 		}
 		defer func() { _ = f.Close() }()
 

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -206,7 +206,7 @@ func renderRun(cmd *cobra.Command, args []string, opts *renderOptions) error {
 		var err error
 		lang, err = language.Parse(opts.locale)
 		if err != nil {
-			return fmt.Errorf("invalid locale: %v", err)
+			return fmt.Errorf("invalid locale: %w", err)
 		}
 	}
 
@@ -274,7 +274,7 @@ func loadConfig(configPath string, args []string) (string, map[string]any, []str
 
 		err = json.NewDecoder(f).Decode(&config)
 		if err != nil {
-			return "", nil, args, fmt.Errorf("unmarshaling JSON %v: %w", configPath, err)
+			return "", nil, args, fmt.Errorf("unmarshaling JSON %s: %w", configPath, err)
 		}
 	}
 

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -148,14 +148,14 @@ func renderRun(cmd *cobra.Command, args []string, opts *renderOptions) error {
 	// check if path exists, and whether it is a directory or a file
 	info, err := os.Stat(path)
 	if err != nil {
-		return fmt.Errorf("failed to stat %s: %w", path, err)
+		return fmt.Errorf("stat %s: %w", path, err)
 	}
 
 	var outPath string
 	if info.IsDir() {
 		abs, err := filepath.Abs(path)
 		if err != nil {
-			return fmt.Errorf("failed to get absolute path for %s: %w", path, err)
+			return fmt.Errorf("absolute path for %s: %w", path, err)
 		}
 
 		outPath = filepath.Join(path, filepath.Base(abs))
@@ -223,7 +223,7 @@ func renderRun(cmd *cobra.Command, args []string, opts *renderOptions) error {
 		loader.WithFilters(filters),
 	)
 	if err != nil {
-		return fmt.Errorf("error rendering: %w", err)
+		return err
 	}
 
 	if outPath == "-" {
@@ -260,7 +260,7 @@ func loadConfig(configPath string, args []string) (string, map[string]any, []str
 
 	starPath, err := filepath.Abs(starPath)
 	if err != nil {
-		return "", nil, args, fmt.Errorf("failed to get absolute path for %s: %w", starPath, err)
+		return "", nil, args, fmt.Errorf("absolute path for %s: %w", starPath, err)
 	}
 
 	config := map[string]any{}
@@ -274,7 +274,7 @@ func loadConfig(configPath string, args []string) (string, map[string]any, []str
 
 		err = json.NewDecoder(f).Decode(&config)
 		if err != nil {
-			return "", nil, args, fmt.Errorf("failed to unmarshal JSON %v: %w", configPath, err)
+			return "", nil, args, fmt.Errorf("unmarshaling JSON %v: %w", configPath, err)
 		}
 	}
 

--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -57,25 +57,25 @@ func schemaRun(cmd *cobra.Command, args []string, opts *schemaOptions) error {
 		cmd.Context(), path, runtime.WithCanvasMeta(opts.meta.Metadata),
 	)
 	if err != nil {
-		return fmt.Errorf("failed to load applet: %w", err)
+		return fmt.Errorf("loading applet: %w", err)
 	}
 	defer func() { _ = applet.Close() }()
 
 	if opts.output == "" || opts.output == "-" {
 		buf, err := json.MarshalIndent(applet.Schema, "", "  ")
 		if err != nil {
-			return fmt.Errorf("failed to marshal JSON: %w", err)
+			return fmt.Errorf("marshaling JSON: %w", err)
 		}
 		fmt.Println(string(buf))
 	} else {
 		b, err := json.Marshal(applet.Schema)
 		if err != nil {
-			return fmt.Errorf("failed to marshal JSON: %w", err)
+			return fmt.Errorf("marshaling JSON: %w", err)
 		}
 
 		err = os.WriteFile(opts.output, b, 0644)
 		if err != nil {
-			return fmt.Errorf("failed to write schema to file: %w", err)
+			return fmt.Errorf("writing schema: %w", err)
 		}
 	}
 

--- a/render/animation/transformation.go
+++ b/render/animation/transformation.go
@@ -74,7 +74,7 @@ func findKeyframes(arr []Keyframe, p float64) (Keyframe, Keyframe, error) {
 	}
 
 	return defaultKeyframeFrom, defaultKeyframeTo,
-		fmt.Errorf("failed to find adjacent keyframes for percentage: %f (this should be unreachable!?)", p)
+		fmt.Errorf("finding adjacent keyframes for percentage: %f (this should be unreachable)", p)
 }
 
 // Transformation makes it possible to animate a child widget by

--- a/render/emoji.go
+++ b/render/emoji.go
@@ -60,7 +60,7 @@ func (e *Emoji) Init(*starlark.Thread) error {
 
 	srcImg, _, err := emoji.Get(e.EmojiStr, true)
 	if err != nil {
-		return fmt.Errorf("failed to get emoji: %w", err)
+		return fmt.Errorf("getting emoji: %w", err)
 	}
 
 	w, h := srcImg.Bounds().Dx(), srcImg.Bounds().Dy()

--- a/render/emoji/emoji.go
+++ b/render/emoji/emoji.go
@@ -60,7 +60,7 @@ func Get(s string, tryVariation bool) (*image.NRGBA, bool, error) {
 	// Get the emoji sprite sheet
 	sheet, err := Sheet()
 	if err != nil {
-		return nil, exists, fmt.Errorf("failed to load emoji sheet: %w", err)
+		return nil, exists, fmt.Errorf("loading emoji sheet: %w", err)
 	}
 
 	// Create source image for this emoji with padding applied horizontally.

--- a/render/image.go
+++ b/render/image.go
@@ -70,7 +70,7 @@ func (p *Image) InitFromGIF(data []byte) error {
 	// Consider using WebP instead.
 	img, err := gif.DecodeAll(bytes.NewReader(data))
 	if err != nil {
-		return fmt.Errorf("decoding image data: %v", err)
+		return fmt.Errorf("decoding image data: %w", err)
 	}
 
 	p.Delay = img.Delay[0] * 10
@@ -130,7 +130,7 @@ func (p *Image) InitFromGIF(data []byte) error {
 func (p *Image) InitFromImage(data []byte) error {
 	im, _, err := image.Decode(bytes.NewReader(data))
 	if err != nil {
-		return fmt.Errorf("decoding image data: %v", err)
+		return fmt.Errorf("decoding image data: %w", err)
 	}
 
 	p.imgs = []image.Image{im}

--- a/render/image_webp_cgo.go
+++ b/render/image_webp_cgo.go
@@ -12,12 +12,12 @@ import (
 func (p *Image) InitFromWebP(data []byte) error {
 	decoder, err := webp.NewAnimationDecoder(data)
 	if err != nil {
-		return fmt.Errorf("creating animation decoder: %v", err)
+		return fmt.Errorf("creating animation decoder: %w", err)
 	}
 
 	img, err := decoder.Decode()
 	if err != nil {
-		return fmt.Errorf("decoding image data: %v", err)
+		return fmt.Errorf("decoding image data: %w", err)
 	}
 
 	p.Delay = img.Timestamp[0]

--- a/runtime/applet.go
+++ b/runtime/applet.go
@@ -206,12 +206,12 @@ func NewAppletFromFS(ctx context.Context, fsys fs.FS, id string, opts ...AppletO
 	id = path.Clean(id)
 	if info, err := fs.Stat(fsys, id); err == nil && info.IsDir() {
 		if fsys, err = fs.Sub(fsys, id); err != nil {
-			return nil, fmt.Errorf("failed to load applet: %w", err)
+			return nil, fmt.Errorf("loading applet: %w", err)
 		}
 		id = "."
 	} else {
 		if fsys, err = fs.Sub(fsys, path.Dir(id)); err != nil {
-			return nil, fmt.Errorf("failed to load applet: %w", err)
+			return nil, fmt.Errorf("loading applet: %w", err)
 		}
 		id = path.Base(id)
 	}
@@ -259,7 +259,7 @@ var ErrStarSuffix = fmt.Errorf("script file must have suffix .star")
 func NewAppletFromPath(ctx context.Context, path string, opts ...AppletOption) (*Applet, error) {
 	info, err := os.Stat(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to stat %s: %w", path, err)
+		return nil, fmt.Errorf("stat %s: %w", path, err)
 	}
 
 	dir := path
@@ -273,7 +273,7 @@ func NewAppletFromPath(ctx context.Context, path string, opts ...AppletOption) (
 
 	root, err := os.OpenRoot(dir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open root for %s: %w", path, err)
+		return nil, fmt.Errorf("opening root for %s: %w", path, err)
 	}
 
 	a, err := NewAppletFromRoot(ctx, root, filepath.Base(path), opts...)

--- a/runtime/applet.go
+++ b/runtime/applet.go
@@ -374,7 +374,7 @@ func (app *Applet) CallSchemaHandler(ctx context.Context, handlerName, parameter
 
 	resultVal, err := app.Call(ctx, handler.Function, args...)
 	if err != nil {
-		return "", fmt.Errorf("calling schema handler %s: %v", handlerName, err)
+		return "", fmt.Errorf("calling schema handler %s: %w", handlerName, err)
 	}
 
 	switch handler.ReturnType {
@@ -484,7 +484,7 @@ func (a *Applet) load(ctx context.Context, fsys fs.FS) (err error) {
 	// list files in the root directory of fsys
 	rootDir, err := fs.ReadDir(fsys, ".")
 	if err != nil {
-		return fmt.Errorf("reading root directory: %v", err)
+		return fmt.Errorf("reading root directory: %w", err)
 	}
 
 	if err := a.loadManifest(fsys, ManifestPath); err != nil && !errors.Is(err, os.ErrNotExist) {
@@ -622,7 +622,7 @@ func (a *Applet) ensureLoaded(ctx context.Context, fsys fs.FS, pathToLoad string
 
 		src, err := fsys.Open(pathToLoad)
 		if err != nil {
-			return fmt.Errorf("reading %s: %v", pathToLoad, err)
+			return fmt.Errorf("reading %s: %w", pathToLoad, err)
 		}
 		defer func() { _ = src.Close() }()
 
@@ -642,7 +642,7 @@ func (a *Applet) ensureLoaded(ctx context.Context, fsys fs.FS, pathToLoad string
 		if mod == nil {
 			srcBytes, err := fs.ReadFile(fsys, pathToLoad)
 			if err != nil {
-				return fmt.Errorf("reading %s: %v", pathToLoad, err)
+				return fmt.Errorf("reading %s: %w", pathToLoad, err)
 			}
 
 			_, mod, err = starlark.SourceProgramOptions(
@@ -657,7 +657,7 @@ func (a *Applet) ensureLoaded(ctx context.Context, fsys fs.FS, pathToLoad string
 				predeclared.Has,
 			)
 			if err != nil {
-				return fmt.Errorf("starlark.SourceProgram: %v", err)
+				return fmt.Errorf("starlark.SourceProgram: %w", err)
 			}
 
 			if a.compiledCache != nil {
@@ -674,7 +674,7 @@ func (a *Applet) ensureLoaded(ctx context.Context, fsys fs.FS, pathToLoad string
 
 		globals, err := mod.Init(thread, predeclared)
 		if err != nil {
-			return fmt.Errorf("initializing module: %v", err)
+			return fmt.Errorf("initializing module: %w", err)
 		}
 
 		globals.Freeze()

--- a/runtime/appletcache/appletcache.go
+++ b/runtime/appletcache/appletcache.go
@@ -53,26 +53,26 @@ func New(root *os.Root) (*Cache, error) {
 		cache.nest = true
 
 		if err := os.Mkdir(dir, 0755); err != nil && !errors.Is(err, fs.ErrExist) {
-			return nil, fmt.Errorf("failed to create starcache dir: %w", err)
+			return nil, fmt.Errorf("creating starcache dir: %w", err)
 		}
 
 		var err error
 		if cache.root, err = os.OpenRoot(dir); err != nil {
-			return nil, fmt.Errorf("failed to open cache root: %w", err)
+			return nil, fmt.Errorf("opening starcache root: %w", err)
 		}
 	} else {
 		if err := root.Mkdir(starCacheDir, 0755); err != nil && !errors.Is(err, fs.ErrExist) {
-			return nil, fmt.Errorf("failed to create starcache dir: %w", err)
+			return nil, fmt.Errorf("creating starcache dir: %w", err)
 		}
 
 		var err error
 		if cache.root, err = root.OpenRoot(starCacheDir); err != nil {
-			return nil, fmt.Errorf("failed to open starcache root: %w", err)
+			return nil, fmt.Errorf("opening starcache root: %w", err)
 		}
 
 		if err := cache.root.WriteFile(".gitignore", []byte("*\n"), 0644); err != nil && !errors.Is(err, fs.ErrExist) {
 			_ = cache.root.Close()
-			return nil, fmt.Errorf("failed to write starcache .gitignore: %w", err)
+			return nil, fmt.Errorf("writing starcache .gitignore: %w", err)
 		}
 	}
 
@@ -99,7 +99,7 @@ func (c Cache) NewWriter(_ context.Context, id, key string, sourceFile fs.File) 
 
 	if dir := path.Dir(cachePath); dir != "." {
 		if err := c.root.Mkdir(id, 0755); err != nil && !errors.Is(err, fs.ErrExist) {
-			return nil, fmt.Errorf("failed to create cache dir: %w", err)
+			return nil, fmt.Errorf("creating cache dir: %w", err)
 		}
 	}
 

--- a/runtime/cache.go
+++ b/runtime/cache.go
@@ -130,7 +130,7 @@ func cacheGet(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple,
 		args, kwargs,
 		"key", &key,
 	); err != nil {
-		return nil, fmt.Errorf("unpacking arguments for cache.get: %v", err)
+		return nil, fmt.Errorf("unpacking arguments for cache.get: %w", err)
 	}
 
 	cacheKey := scopedCacheKey(thread, key)
@@ -170,7 +170,7 @@ func cacheSet(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple,
 		"value", &val,
 		"ttl_seconds?", &ttl,
 	); err != nil {
-		return nil, fmt.Errorf("unpacking arguments for cache.set: %v", err)
+		return nil, fmt.Errorf("unpacking arguments for cache.set: %w", err)
 	}
 
 	cacheKey := scopedCacheKey(thread, key)

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -99,7 +99,7 @@ func (a AppletConfig) getString(_ *starlark.Thread, _ *starlark.Builtin, args st
 		"str", args, kwargs, 1,
 		&key, &def,
 	); err != nil {
-		return nil, fmt.Errorf("unpacking arguments for config.str: %v", err)
+		return nil, fmt.Errorf("unpacking arguments for config.str: %w", err)
 	}
 
 	if val, isDefault, ok := a.get(key.GoString()); ok && (!isDefault || len(args) == 1) {
@@ -119,7 +119,7 @@ func (a AppletConfig) getBoolean(_ *starlark.Thread, _ *starlark.Builtin, args s
 		"bool", args, kwargs, 1,
 		&key, &def,
 	); err != nil {
-		return nil, fmt.Errorf("unpacking arguments for config.bool: %v", err)
+		return nil, fmt.Errorf("unpacking arguments for config.bool: %w", err)
 	}
 
 	if val, isDefault, ok := a.get(key.GoString()); ok && (!isDefault || len(args) == 1) {

--- a/runtime/gen/main.go
+++ b/runtime/gen/main.go
@@ -84,12 +84,12 @@ func (g GeneratedAttr) GoPath() string {
 func (g GeneratedAttr) Code() (string, error) {
 	tmpl, err := loadTemplate(g.TemplatePath)
 	if err != nil {
-		return "", fmt.Errorf("failed to load template for attribute %s: %w", g.StarlarkName, err)
+		return "", fmt.Errorf("loading template for attribute %s: %w", g.StarlarkName, err)
 	}
 
 	var buf strings.Builder
 	if err := tmpl.Execute(&buf, g); err != nil {
-		return "", fmt.Errorf("failed to render template for attribute %s: %w", g.StarlarkName, err)
+		return "", fmt.Errorf("rendering template for attribute %s: %w", g.StarlarkName, err)
 	}
 	return buf.String(), nil
 }

--- a/runtime/httpcache.go
+++ b/runtime/httpcache.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"iter"
 	"log/slog"
@@ -64,12 +65,14 @@ func InitHTTP(cache Cache) {
 	starlarkhttp.StarlarkHTTPClient = httpClient
 }
 
+var ErrTimeout = errors.New("HTTP timeout")
+
 // RoundTrip is an approximation of what our internal HTTP proxy does. It should
 // behave the same way, and any discrepancy should be considered a bug.
 func (c *cacheClient) RoundTrip(req *http.Request) (*http.Response, error) {
 	ctx := req.Context()
 
-	ctx, cancel := context.WithTimeout(ctx, HTTPTimeout)
+	ctx, cancel := context.WithTimeoutCause(ctx, HTTPTimeout, fmt.Errorf("%w after %s", ErrTimeout, HTTPTimeout))
 	defer cancel() // need to do this to not leak a goroutine
 
 	key, err := cacheKey(req)
@@ -97,7 +100,10 @@ func (c *cacheClient) RoundTrip(req *http.Request) (*http.Response, error) {
 		if err != nil {
 			// if httputil.DumpResponse fails, it leaves the response body in an
 			// undefined state, so we cannot continue
-			return nil, fmt.Errorf("failed to serialize response for cache: %v (%s)", err, resp.Status)
+			if cause := context.Cause(ctx); cause != nil {
+				err = cause
+			}
+			return nil, fmt.Errorf("reading response body: %w", err)
 		}
 
 		ttl := DetermineTTL(req, resp, nil)

--- a/runtime/httpcache.go
+++ b/runtime/httpcache.go
@@ -77,7 +77,7 @@ func (c *cacheClient) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	key, err := cacheKey(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate cache key: %w", err)
+		return nil, fmt.Errorf("generating cache key: %w", err)
 	}
 
 	if req.Method == http.MethodGet || req.Method == http.MethodHead || req.Method == http.MethodPost {
@@ -119,7 +119,7 @@ func cacheKey(req *http.Request) (string, error) {
 	req.Header.Del(TTLHeader)
 	r, err := httputil.DumpRequest(req, true)
 	if err != nil {
-		return "", fmt.Errorf("%s: %w", "failed to serialize request", err)
+		return "", fmt.Errorf("serializing request: %w", err)
 	}
 	if ttl != "" {
 		req.Header.Set(TTLHeader, ttl)

--- a/runtime/modules/humanize/humanize.go
+++ b/runtime/modules/humanize/humanize.go
@@ -96,7 +96,7 @@ func urlDecode(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple
 	unescapedUrl, decodeErr := url.QueryUnescape(starUrl.GoString())
 
 	if decodeErr != nil {
-		return nil, fmt.Errorf("decoding url %s: %s", starUrl.GoString(), decodeErr)
+		return nil, fmt.Errorf("decoding url %s: %w", starUrl.GoString(), decodeErr)
 	}
 
 	return starlark.String(unescapedUrl), nil
@@ -234,7 +234,7 @@ func parseBytes(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tupl
 	formatted, err := gohumanize.ParseBytes(starSize.GoString())
 
 	if err != nil {
-		return nil, fmt.Errorf("parsing bytes: %s: %s", starSize.GoString(), err)
+		return nil, fmt.Errorf("parsing bytes: %s: %w", starSize.GoString(), err)
 	}
 
 	return starlark.MakeUint64(formatted), nil
@@ -470,7 +470,7 @@ func wordSeries(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tupl
 	words, err := getWordList(starWords)
 
 	if err != nil {
-		return nil, fmt.Errorf("getting word list: %s", err)
+		return nil, fmt.Errorf("getting word list: %w", err)
 	}
 
 	val := gohumanizeEnglish.WordSeries(words, starConjunction.GoString())
@@ -495,7 +495,7 @@ func oxfordWordSeries(thread *starlark.Thread, _ *starlark.Builtin, args starlar
 	words, err := getWordList(starWords)
 
 	if err != nil {
-		return nil, fmt.Errorf("getting word list: %s", err)
+		return nil, fmt.Errorf("getting word list: %w", err)
 	}
 
 	val := gohumanizeEnglish.OxfordWordSeries(words, starConjunction.GoString())

--- a/runtime/modules/humanize/humanize.go
+++ b/runtime/modules/humanize/humanize.go
@@ -96,7 +96,7 @@ func urlDecode(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple
 	unescapedUrl, decodeErr := url.QueryUnescape(starUrl.GoString())
 
 	if decodeErr != nil {
-		return nil, fmt.Errorf("unable to decode url: %s: %s", starUrl.GoString(), decodeErr)
+		return nil, fmt.Errorf("decoding url %s: %s", starUrl.GoString(), decodeErr)
 	}
 
 	return starlark.String(unescapedUrl), nil
@@ -234,7 +234,7 @@ func parseBytes(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tupl
 	formatted, err := gohumanize.ParseBytes(starSize.GoString())
 
 	if err != nil {
-		return nil, fmt.Errorf("unable to parse bytes: %s: %s", starSize.GoString(), err)
+		return nil, fmt.Errorf("parsing bytes: %s: %s", starSize.GoString(), err)
 	}
 
 	return starlark.MakeUint64(formatted), nil
@@ -470,7 +470,7 @@ func wordSeries(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tupl
 	words, err := getWordList(starWords)
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to get word list: %s", err)
+		return nil, fmt.Errorf("getting word list: %s", err)
 	}
 
 	val := gohumanizeEnglish.WordSeries(words, starConjunction.GoString())
@@ -495,7 +495,7 @@ func oxfordWordSeries(thread *starlark.Thread, _ *starlark.Builtin, args starlar
 	words, err := getWordList(starWords)
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to get word list: %s", err)
+		return nil, fmt.Errorf("getting word list: %s", err)
 	}
 
 	val := gohumanizeEnglish.OxfordWordSeries(words, starConjunction.GoString())

--- a/runtime/modules/xpath/xpath.go
+++ b/runtime/modules/xpath/xpath.go
@@ -47,12 +47,12 @@ func xPathLoads(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tupl
 		args, kwargs,
 		"xml", &xml,
 	); err != nil {
-		return nil, fmt.Errorf("unpacking arguments for loads: %v", err)
+		return nil, fmt.Errorf("unpacking arguments for loads: %w", err)
 	}
 
 	doc, err := xmlquery.Parse(strings.NewReader(xml.GoString()))
 	if err != nil {
-		return nil, fmt.Errorf("parsing XML: %v", err)
+		return nil, fmt.Errorf("parsing XML: %w", err)
 	}
 
 	x := &XPath{
@@ -74,14 +74,14 @@ func xPathQueryNode(thread *starlark.Thread, b *starlark.Builtin, args starlark.
 		args, kwargs,
 		"path", &path,
 	); err != nil {
-		return nil, fmt.Errorf("unpacking arguments for query: %v", err)
+		return nil, fmt.Errorf("unpacking arguments for query: %w", err)
 	}
 
 	x := b.Receiver().(*XPath)
 
 	node, err := xmlquery.Query(x.doc, path.GoString())
 	if err != nil {
-		return nil, fmt.Errorf("querying: %v", err)
+		return nil, fmt.Errorf("querying: %w", err)
 	}
 
 	if node == nil {
@@ -106,14 +106,14 @@ func xPathQuery(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tupl
 		args, kwargs,
 		"path", &path,
 	); err != nil {
-		return nil, fmt.Errorf("unpacking arguments for query: %v", err)
+		return nil, fmt.Errorf("unpacking arguments for query: %w", err)
 	}
 
 	x := b.Receiver().(*XPath)
 
 	node, err := xmlquery.Query(x.doc, path.GoString())
 	if err != nil {
-		return nil, fmt.Errorf("querying: %v", err)
+		return nil, fmt.Errorf("querying: %w", err)
 	}
 
 	if node == nil {
@@ -130,14 +130,14 @@ func xPathQueryAllNodes(thread *starlark.Thread, b *starlark.Builtin, args starl
 		args, kwargs,
 		"path", &path,
 	); err != nil {
-		return nil, fmt.Errorf("unpacking arguments for query_all: %v", err)
+		return nil, fmt.Errorf("unpacking arguments for query_all: %w", err)
 	}
 
 	x := b.Receiver().(*XPath)
 
 	nodes, err := xmlquery.QueryAll(x.doc, path.GoString())
 	if err != nil {
-		return nil, fmt.Errorf("querying all: %v", err)
+		return nil, fmt.Errorf("querying all: %w", err)
 	}
 
 	results := make([]starlark.Value, 0, len(nodes))
@@ -163,14 +163,14 @@ func xPathQueryAll(thread *starlark.Thread, b *starlark.Builtin, args starlark.T
 		args, kwargs,
 		"path", &path,
 	); err != nil {
-		return nil, fmt.Errorf("unpacking arguments for query_all: %v", err)
+		return nil, fmt.Errorf("unpacking arguments for query_all: %w", err)
 	}
 
 	x := b.Receiver().(*XPath)
 
 	nodes, err := xmlquery.QueryAll(x.doc, path.GoString())
 	if err != nil {
-		return nil, fmt.Errorf("querying all: %v", err)
+		return nil, fmt.Errorf("querying all: %w", err)
 	}
 
 	nodeTexts := make([]starlark.Value, 0, len(nodes))

--- a/runtime/modules/xpath/xpath.go
+++ b/runtime/modules/xpath/xpath.go
@@ -47,7 +47,7 @@ func xPathLoads(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tupl
 		args, kwargs,
 		"xml", &xml,
 	); err != nil {
-		return nil, fmt.Errorf("unpacking arguments for cache.get: %v", err)
+		return nil, fmt.Errorf("unpacking arguments for loads: %v", err)
 	}
 
 	doc, err := xmlquery.Parse(strings.NewReader(xml.GoString()))

--- a/runtime/secret.go
+++ b/runtime/secret.go
@@ -41,18 +41,18 @@ func (sek *SecretEncryptionKey) Encrypt(appID, plaintext string) (string, error)
 	r := bytes.NewReader(sek.PublicKeysetJSON)
 	kh, err := keyset.ReadWithNoSecrets(keyset.NewJSONReader(r))
 	if err != nil {
-		return "", fmt.Errorf("%s: %w", "reading keyset JSON", err)
+		return "", fmt.Errorf("reading keyset JSON: %w", err)
 	}
 
 	enc, err := hybrid.NewHybridEncrypt(kh)
 	if err != nil {
-		return "", fmt.Errorf("%s: %w", "NewHybridEncrypt", err)
+		return "", fmt.Errorf("NewHybridEncrypt: %w", err)
 	}
 
 	context := []byte(appID)
 	ciphertext, err := enc.Encrypt([]byte(plaintext), context)
 	if err != nil {
-		return "", fmt.Errorf("%s: %w", "encrypting secret", err)
+		return "", fmt.Errorf("encrypting secret: %w", err)
 	}
 
 	return base64.StdEncoding.EncodeToString(ciphertext), nil
@@ -84,12 +84,12 @@ func (sdk *SecretDecryptionKey) decrypterForApp(a *Applet) (decrypter, error) {
 	r := bytes.NewReader(sdk.EncryptedKeysetJSON)
 	kh, err := keyset.Read(keyset.NewJSONReader(r), sdk.KeyEncryptionKey)
 	if err != nil {
-		return nil, fmt.Errorf("%s: %w", "reading keyset JSON", err)
+		return nil, fmt.Errorf("reading keyset JSON: %w", err)
 	}
 
 	dec, err := hybrid.NewHybridDecrypt(kh)
 	if err != nil {
-		return nil, fmt.Errorf("%s: %w", "NewHybridDecrypt", err)
+		return nil, fmt.Errorf("NewHybridDecrypt: %w", err)
 	}
 
 	context := []byte(a.ID)
@@ -98,7 +98,7 @@ func (sdk *SecretDecryptionKey) decrypterForApp(a *Applet) (decrypter, error) {
 		v := regexp.MustCompile(`\s`).ReplaceAllString(s.GoString(), "")
 		ciphertext, err := base64.StdEncoding.DecodeString(v)
 		if err != nil {
-			return "", fmt.Errorf("base64 decoding of secret: %s: %w", s, err)
+			return "", fmt.Errorf("base64 decoding secret: %s: %w", s, err)
 		}
 
 		cleartext, err := dec.Decrypt(ciphertext, context)
@@ -131,7 +131,7 @@ func secretDecrypt(thread *starlark.Thread, _ *starlark.Builtin, args starlark.T
 		args, kwargs,
 		0, &encryptedVal,
 	); err != nil {
-		return nil, fmt.Errorf("unpacking arguments for secret.decrypt: %v", err)
+		return nil, fmt.Errorf("unpacking arguments for secret.decrypt: %w", err)
 	}
 
 	dec := decrypterForThread(thread)

--- a/server/loader/loader.go
+++ b/server/loader/loader.go
@@ -326,7 +326,7 @@ func (l *Loader) Meta() canvas.Metadata {
 func RenderApplet(ctx context.Context, path string, config map[string]any, options ...Option) ([]byte, []string, error) {
 	info, err := os.Stat(path)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to stat file: %w", err)
+		return nil, nil, fmt.Errorf("stat %s: %w", path, err)
 	}
 
 	dir := path
@@ -336,7 +336,7 @@ func RenderApplet(ctx context.Context, path string, config map[string]any, optio
 
 	root, err := os.OpenRoot(dir)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to open root: %w", err)
+		return nil, nil, fmt.Errorf("opening root: %w", err)
 	}
 	defer func() { _ = root.Close() }()
 
@@ -395,7 +395,7 @@ func renderApplet(ctx context.Context, applet *runtime.Applet, conf *RenderConfi
 
 	roots, err := applet.RunWithConfig(ctx, conf.Config)
 	if err != nil {
-		return nil, fmt.Errorf("error running script: %w", err)
+		return nil, fmt.Errorf("running script: %w", err)
 	}
 
 	screens := encode.ScreensFromRoots(roots, meta.ScaledWidth(), meta.ScaledHeight())
@@ -432,7 +432,7 @@ func renderApplet(ctx context.Context, applet *runtime.Applet, conf *RenderConfi
 		img, err = screens.EncodeGIF(ctx, maxDuration, filter)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("error rendering: %w", err)
+		return nil, fmt.Errorf("rendering: %w", err)
 	}
 
 	return img, nil

--- a/server/loader/loader.go
+++ b/server/loader/loader.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -372,13 +373,15 @@ func RenderAppletRoot(ctx context.Context, root *os.Root, path string, config ma
 	return img, output, nil
 }
 
+var ErrTimeout = errors.New("render timeout")
+
 func renderApplet(ctx context.Context, applet *runtime.Applet, conf *RenderConfig) ([]byte, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	if conf.Timeout > 0 {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeoutCause(ctx, conf.Timeout, fmt.Errorf("timeout after %s", conf.Timeout))
+		ctx, cancel = context.WithTimeoutCause(ctx, conf.Timeout, fmt.Errorf("%w after %s", ErrTimeout, conf.Timeout))
 		defer cancel()
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -52,7 +52,7 @@ func NewServer(
 
 	root, err := os.OpenRoot(dir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open root for %s: %w", path, err)
+		return nil, fmt.Errorf("opening root for %s: %w", path, err)
 	}
 
 	w := NewWatcher(dir, fileChanges)

--- a/tools/repo/repo.go
+++ b/tools/repo/repo.go
@@ -59,7 +59,7 @@ func Root(dir string) (string, error) {
 		if err, ok := errors.AsType[*exec.ExitError](err); ok {
 			stderr = err.Stderr
 		}
-		return "", fmt.Errorf("failed to get repo root: %w: %s", err, string(stderr))
+		return "", fmt.Errorf("getting repo root: %w: %s", err, string(stderr))
 	}
 
 	return string(bytes.TrimSpace(out)), nil


### PR DESCRIPTION
Improves error messages:
- Render timeout has been changed from `timeout after 30s` to `render timeout after 30s`
- HTTP timeout has been changed from `context deadline exceeded` to `HTTP timeout after 5s`
- Stripped redundant `error ...` and `failed to ...` prefixes
  - For example, `Error: error rendering: error running script: Traceback ...` is now `Error: running script: Traceback ...`