### PR TITLE
add option to show grid for easier spacing reference

### DIFF
--- a/frontend/src/features/controls/Controls.jsx
+++ b/frontend/src/features/controls/Controls.jsx
@@ -14,9 +14,10 @@ import UploadFileIcon from '@mui/icons-material/UploadFile';
 import DownloadIcon from '@mui/icons-material/Download';
 import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import ImageIcon from '@mui/icons-material/Image';
+import GridOnIcon from '@mui/icons-material/GridOn';
 import { resetConfig, setConfig } from '../config/actions';
 import { set } from '../config/configSlice';
-import { setScale, setTimezone, setLocale } from '../preview/previewSlice';
+import { setScale, setTimezone, setLocale, toggleGrid } from '../preview/previewSlice';
 
 export default function Controls() {
     const preview = useSelector(state => state.preview);
@@ -175,6 +176,7 @@ export default function Controls() {
                 <Button fullWidth={fullWidth} variant="outlined" startIcon={<UploadFileIcon />} onClick={() => selectConfig()}>Import Config</Button>
                 <Button fullWidth={fullWidth} variant="outlined" startIcon={<DownloadIcon />} onClick={() => downloadConfig()}>Export Config</Button>
                 <Button fullWidth={fullWidth} variant="outlined" startIcon={<RestartAltIcon />} onClick={() => resetSchema()}>Reset</Button>
+                <Button fullWidth={fullWidth} variant={preview.value.show_grid ? "contained" : "outlined"} startIcon={<GridOnIcon />} aria-pressed={preview.value.show_grid} onClick={() => dispatch(toggleGrid())}>Show Grid</Button>
                 <Button fullWidth={fullWidth} variant="contained" startIcon={<ImageIcon />} onClick={() => downloadPreview()}>Export Image</Button>
             </Stack>
             <Stack spacing={2} direction={{ xs: 'column', sm: 'row' }} alignItems="flex-start" flexWrap="wrap">

--- a/frontend/src/features/preview/Preview.jsx
+++ b/frontend/src/features/preview/Preview.jsx
@@ -20,12 +20,19 @@ export default function Preview() {
 
     let dotsUrl = new URL('./api/v1/dots.svg', document.location);
     const scale = preview.value.is2x ? 2 : 1;
+    const gridWidth = (preview.value.width || 64) * scale;
+    const gridHeight = (preview.value.height || 32) * scale;
     if (preview.value.width) {
-        dotsUrl.searchParams.set('w', String(preview.value.width * scale));
+        dotsUrl.searchParams.set('w', String(gridWidth));
     }
     if (preview.value.height) {
-        dotsUrl.searchParams.set('h', String(preview.value.height * scale));
+        dotsUrl.searchParams.set('h', String(gridHeight));
     }
+
+    const gridStyle = {
+        '--grid-cell-width': `${100 / gridWidth}%`,
+        '--grid-cell-height': `${100 / gridHeight}%`,
+    };
 
     return (
         <Paper sx={{ backgroundColor: "black", backgroundImage: 'none' }} className={styles.container}>
@@ -43,6 +50,7 @@ export default function Preview() {
                     style={{ maskImage: `url("${dotsUrl}")`, WebkitMaskImage: `url("${dotsUrl}")` }}
                 />
             )}
+            {preview.value.show_grid && <div className={styles.grid} style={gridStyle} aria-hidden="true" />}
         </Paper>
     );
 }

--- a/frontend/src/features/preview/Preview.jsx
+++ b/frontend/src/features/preview/Preview.jsx
@@ -20,8 +20,10 @@ export default function Preview() {
 
     let dotsUrl = new URL('./api/v1/dots.svg', document.location);
     const scale = preview.value.is2x ? 2 : 1;
-    const gridWidth = (preview.value.width || 64) * scale;
-    const gridHeight = (preview.value.height || 32) * scale;
+    const logicalWidth = preview.value.width || 64;
+    const logicalHeight = preview.value.height || 32;
+    const gridWidth = logicalWidth * scale;
+    const gridHeight = logicalHeight * scale;
     if (preview.value.width) {
         dotsUrl.searchParams.set('w', String(gridWidth));
     }
@@ -30,8 +32,8 @@ export default function Preview() {
     }
 
     const gridStyle = {
-        '--grid-cell-width': `${100 / gridWidth}%`,
-        '--grid-cell-height': `${100 / gridHeight}%`,
+        '--grid-cell-width': (100 / logicalWidth) + '%',
+        '--grid-cell-height': (100 / logicalHeight) + '%',
     };
 
     return (

--- a/frontend/src/features/preview/previewSlice.js
+++ b/frontend/src/features/preview/previewSlice.js
@@ -13,6 +13,7 @@ export const previewSlice = createSlice({
             is2x: null,
             timezone: '',
             locale: '',
+            show_grid: false,
         }
     },
     reducers: {
@@ -83,8 +84,17 @@ export const previewSlice = createSlice({
                 }
             }
         },
+        toggleGrid: (state = initialState) => {
+            return {
+                ...state,
+                value: {
+                    ...state.value,
+                    show_grid: !state.value.show_grid,
+                }
+            }
+        },
     },
 });
 
-export const { update, loading, setScale, setTimezone, setLocale } = previewSlice.actions;
+export const { update, loading, setScale, setTimezone, setLocale, toggleGrid } = previewSlice.actions;
 export default previewSlice.reducer;

--- a/frontend/src/features/preview/styles.module.css
+++ b/frontend/src/features/preview/styles.module.css
@@ -4,6 +4,7 @@
 }
 
 .image {
+	display: block;
 	image-rendering: pixelated;
 	image-rendering: -moz-crisp-edges;
 	image-rendering: crisp-edges;
@@ -12,4 +13,15 @@
 	-webkit-mask-repeat: no-repeat;
 	mask-size: cover;
 	mask-repeat: no-repeat;
+}
+
+.grid {
+	background-image:
+		linear-gradient(to right, rgba(220, 220, 220, 0.45) 1px, transparent 1px),
+		linear-gradient(to bottom, rgba(220, 220, 220, 0.45) 1px, transparent 1px);
+	background-size: var(--grid-cell-width) var(--grid-cell-height);
+	box-shadow: inset 0 0 0 1px rgba(220, 220, 220, 0.45);
+	inset: 0;
+	pointer-events: none;
+	position: absolute;
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -338,6 +338,7 @@ func buildOptions(options any) ([]SchemaOption, error) {
 	return schemaOptions, nil
 }
 
+//nolint:govet // false positive: reflect constants grouping
 func isFieldSet(fl validator.FieldLevel) (bool, bool) {
 	switch fl.Field().Kind() {
 	case reflect.Map, reflect.Ptr, reflect.Interface:


### PR DESCRIPTION
I was having a difficult time lining up pixels based on the grid. I thought it would be nice if there was a grid to help guide that design aspect of development. I added a button to allow you to toggle on and off a grid that aligns with the Tidbyt.

I am not very familiar with this repo or ecosystem. I tested this using `go run . serve examples/clock/clock.star` from `pixlet`, but my hope was that when running `pixlet serve` from `apps`, this experience would appear there too? I assume that interface comes from this repo but I am honestly not sure

Let me know what you think!

### Before
<img width="1216" height="838" alt="Screenshot 2026-06-03 at 6 20 02 PM" src="https://github.com/user-attachments/assets/451df4b6-3148-4552-80c9-2f1e75e2103b" />



### After


https://github.com/user-attachments/assets/468602b5-cc04-4060-b0a1-563d0d2086f9

