### PR TITLE
render(marquee): double Marquee content cap (10× → 20×)

### DIFF
--- a/render/marquee.go
+++ b/render/marquee.go
@@ -6,6 +6,36 @@ import (
 	"github.com/tronbyt/gg"
 )
 
+// MarqueeMaxContentScale bounds how much larger than the Marquee's own width
+// (horizontal) or height (vertical) the scrolled child may be. It caps the
+// drawing context handed to the child so a runaway app can't allocate an
+// enormous canvas, while still letting long content (e.g. a WrappedText)
+// scroll fully.
+//
+// Raised from 10 to 20 (2026) now that target devices tolerate larger WebP
+// payloads. This DOUBLES the maximum scrollable length — but only the *spatial*
+// ceiling. Two further limits decide whether that extra content is actually
+// reached on screen, and you must raise them too to benefit:
+//
+//   - Temporal (the usual blocker): the WebP/GIF encoder stops adding frames
+//     once cumulative frame time reaches maxDuration (default 15s). A Marquee
+//     scrolls 1px/frame, so a child longer than
+//     dwell_seconds * 1000 / root_delay_ms pixels is truncated mid-scroll
+//     regardless of this cap — the rest is never encoded into the file, so the
+//     device just loops the partial scroll. Raise maxDuration via the
+//     `--max-duration` / `-d` flag on `pixlet render` / `pixlet serve`, or via
+//     loader.WithMaxDuration(...) when embedding pixlet as a library. In
+//     tronbyt-server this value is the per-app DisplayTime (falling back to the
+//     device DefaultInterval), set in the App Config screen — no code change
+//     needed there.
+//   - Frame count: render.DefaultMaxFrameCount (2000) is a hard upper bound on
+//     total frames; not normally reached at these sizes.
+//
+// Bottom line: to use the larger ceiling, pair it with a longer dwell time
+// (more seconds of scroll baked into the file) and/or a smaller Root delay
+// (more pixels scrolled per second).
+const MarqueeMaxContentScale = 20
+
 // Marquee scrolls its child horizontally or vertically.
 //
 // The `scroll_direction` will be 'horizontal' and will scroll from right
@@ -58,9 +88,9 @@ func (m Marquee) PaintBounds(bounds image.Rectangle, frameIdx int) image.Rectang
 	var cb image.Rectangle
 
 	if m.isVertical() {
-		cb = m.Child.PaintBounds(image.Rect(0, 0, bounds.Dx(), m.Height*10), 0)
+		cb = m.Child.PaintBounds(image.Rect(0, 0, bounds.Dx(), m.Height*MarqueeMaxContentScale), 0)
 	} else {
-		cb = m.Child.PaintBounds(image.Rect(0, 0, m.Width*10, bounds.Dy()), 0)
+		cb = m.Child.PaintBounds(image.Rect(0, 0, m.Width*MarqueeMaxContentScale, bounds.Dy()), 0)
 	}
 
 	if m.isVertical() {
@@ -75,11 +105,11 @@ func (m Marquee) FrameCount(bounds image.Rectangle) int {
 	var cw int
 	var size int
 	if m.isVertical() {
-		cb = m.Child.PaintBounds(image.Rect(0, 0, bounds.Dx(), m.Height*10), 0)
+		cb = m.Child.PaintBounds(image.Rect(0, 0, bounds.Dx(), m.Height*MarqueeMaxContentScale), 0)
 		cw = cb.Dy()
 		size = m.Height
 	} else {
-		cb = m.Child.PaintBounds(image.Rect(0, 0, m.Width*10, bounds.Dy()), 0)
+		cb = m.Child.PaintBounds(image.Rect(0, 0, m.Width*MarqueeMaxContentScale, bounds.Dy()), 0)
 		cw = cb.Dx()
 		size = m.Width
 	}
@@ -109,11 +139,11 @@ func (m Marquee) Paint(dc *gg.Context, bounds image.Rectangle, frameIdx int) {
 	if m.isVertical() {
 		// We'll only scroll frame 0 of the child. Scrolling an
 		// animation would be madness.
-		cb = m.Child.PaintBounds(image.Rect(0, 0, bounds.Dx(), m.Height*10), 0)
+		cb = m.Child.PaintBounds(image.Rect(0, 0, bounds.Dx(), m.Height*MarqueeMaxContentScale), 0)
 		cw = cb.Dy()
 		size = m.Height
 	} else {
-		cb = m.Child.PaintBounds(image.Rect(0, 0, m.Width*10, bounds.Dy()), 0)
+		cb = m.Child.PaintBounds(image.Rect(0, 0, m.Width*MarqueeMaxContentScale, bounds.Dy()), 0)
 		cw = cb.Dx()
 		size = m.Width
 	}
@@ -164,7 +194,7 @@ func (m Marquee) Paint(dc *gg.Context, bounds image.Rectangle, frameIdx int) {
 		dc.DrawRectangle(0, 0, float64(pb.Dx()), float64(pb.Dy()))
 		dc.Clip()
 		dc.Translate(0, float64(offset))
-		m.Child.Paint(dc, image.Rect(0, 0, bounds.Dx(), m.Height*10), 0)
+		m.Child.Paint(dc, image.Rect(0, 0, bounds.Dx(), m.Height*MarqueeMaxContentScale), 0)
 		dc.Pop()
 	} else {
 		offset -= int(align * float64(cb.Dx()))
@@ -172,7 +202,7 @@ func (m Marquee) Paint(dc *gg.Context, bounds image.Rectangle, frameIdx int) {
 		dc.DrawRectangle(0, 0, float64(pb.Dx()), float64(pb.Dy()))
 		dc.Clip()
 		dc.Translate(float64(offset), 0)
-		m.Child.Paint(dc, image.Rect(0, 0, m.Width*10, bounds.Dy()), 0)
+		m.Child.Paint(dc, image.Rect(0, 0, m.Width*MarqueeMaxContentScale, bounds.Dy()), 0)
 		dc.Pop()
 	}
 }

--- a/render/marquee.go
+++ b/render/marquee.go
@@ -6,7 +6,7 @@ import (
 	"github.com/tronbyt/gg"
 )
 
-// MarqueeMaxContentScale bounds how much larger than the Marquee's own width
+// marqueeMaxContentScale bounds how much larger than the Marquee's own width
 // (horizontal) or height (vertical) the scrolled child may be. It caps the
 // drawing context handed to the child so a runaway app can't allocate an
 // enormous canvas, while still letting long content (e.g. a WrappedText)
@@ -34,7 +34,7 @@ import (
 // Bottom line: to use the larger ceiling, pair it with a longer dwell time
 // (more seconds of scroll baked into the file) and/or a smaller Root delay
 // (more pixels scrolled per second).
-const MarqueeMaxContentScale = 20
+const marqueeMaxContentScale = 20
 
 // Marquee scrolls its child horizontally or vertically.
 //
@@ -88,9 +88,9 @@ func (m Marquee) PaintBounds(bounds image.Rectangle, frameIdx int) image.Rectang
 	var cb image.Rectangle
 
 	if m.isVertical() {
-		cb = m.Child.PaintBounds(image.Rect(0, 0, bounds.Dx(), m.Height*MarqueeMaxContentScale), 0)
+		cb = m.Child.PaintBounds(image.Rect(0, 0, bounds.Dx(), m.Height*marqueeMaxContentScale), 0)
 	} else {
-		cb = m.Child.PaintBounds(image.Rect(0, 0, m.Width*MarqueeMaxContentScale, bounds.Dy()), 0)
+		cb = m.Child.PaintBounds(image.Rect(0, 0, m.Width*marqueeMaxContentScale, bounds.Dy()), 0)
 	}
 
 	if m.isVertical() {
@@ -105,11 +105,11 @@ func (m Marquee) FrameCount(bounds image.Rectangle) int {
 	var cw int
 	var size int
 	if m.isVertical() {
-		cb = m.Child.PaintBounds(image.Rect(0, 0, bounds.Dx(), m.Height*MarqueeMaxContentScale), 0)
+		cb = m.Child.PaintBounds(image.Rect(0, 0, bounds.Dx(), m.Height*marqueeMaxContentScale), 0)
 		cw = cb.Dy()
 		size = m.Height
 	} else {
-		cb = m.Child.PaintBounds(image.Rect(0, 0, m.Width*MarqueeMaxContentScale, bounds.Dy()), 0)
+		cb = m.Child.PaintBounds(image.Rect(0, 0, m.Width*marqueeMaxContentScale, bounds.Dy()), 0)
 		cw = cb.Dx()
 		size = m.Width
 	}
@@ -139,11 +139,11 @@ func (m Marquee) Paint(dc *gg.Context, bounds image.Rectangle, frameIdx int) {
 	if m.isVertical() {
 		// We'll only scroll frame 0 of the child. Scrolling an
 		// animation would be madness.
-		cb = m.Child.PaintBounds(image.Rect(0, 0, bounds.Dx(), m.Height*MarqueeMaxContentScale), 0)
+		cb = m.Child.PaintBounds(image.Rect(0, 0, bounds.Dx(), m.Height*marqueeMaxContentScale), 0)
 		cw = cb.Dy()
 		size = m.Height
 	} else {
-		cb = m.Child.PaintBounds(image.Rect(0, 0, m.Width*MarqueeMaxContentScale, bounds.Dy()), 0)
+		cb = m.Child.PaintBounds(image.Rect(0, 0, m.Width*marqueeMaxContentScale, bounds.Dy()), 0)
 		cw = cb.Dx()
 		size = m.Width
 	}
@@ -194,7 +194,7 @@ func (m Marquee) Paint(dc *gg.Context, bounds image.Rectangle, frameIdx int) {
 		dc.DrawRectangle(0, 0, float64(pb.Dx()), float64(pb.Dy()))
 		dc.Clip()
 		dc.Translate(0, float64(offset))
-		m.Child.Paint(dc, image.Rect(0, 0, bounds.Dx(), m.Height*MarqueeMaxContentScale), 0)
+		m.Child.Paint(dc, image.Rect(0, 0, bounds.Dx(), m.Height*marqueeMaxContentScale), 0)
 		dc.Pop()
 	} else {
 		offset -= int(align * float64(cb.Dx()))
@@ -202,7 +202,7 @@ func (m Marquee) Paint(dc *gg.Context, bounds image.Rectangle, frameIdx int) {
 		dc.DrawRectangle(0, 0, float64(pb.Dx()), float64(pb.Dy()))
 		dc.Clip()
 		dc.Translate(float64(offset), 0)
-		m.Child.Paint(dc, image.Rect(0, 0, m.Width*MarqueeMaxContentScale, bounds.Dy()), 0)
+		m.Child.Paint(dc, image.Rect(0, 0, m.Width*marqueeMaxContentScale, bounds.Dy()), 0)
 		dc.Pop()
 	}
 }


### PR DESCRIPTION
## Joe's Notes
this is a long pending item from the original pixlet days.  in 2022 the max height of a marquee was changed to 10x the height (or width) of your device.  text was still being cut off - but because of the 15s hard coded app limit - there wasn't a real point in pushing for more.   Since y'all have changed that paradigm with App Config Display Time & the changes to pixlet - we're really only limited by the 2000 frames thing.    because people have different size displays & I didn't want to make a giant sweeping change around marquee and the downsteam items - I just bumped it from 10x to 20x to give us some more headroom.   Still need to adjust Display Time accordingly to fit the text - if you know it's going to be long.

let me know if you have questions or want more details.



## Summary

Extracts the hard-coded `*10` child-size multiplier in `Marquee` into a named constant `MarqueeMaxContentScale` and raises it from **10 → 20**, doubling the maximum length of content (e.g. a `WrappedText`) that a `Marquee` can scroll before it is spatially clipped. Applies to **both** scroll directions (horizontal width and vertical height).

## Motivation

Long scrolling text in real apps gets cut off. A vertical `Marquee` measures and paints its child within `Height * 10`, so at the common `height = 32` the child is clamped at **320px (~40 lines of `tb-8`)** no matter how long it is allowed to scroll — anything past that is never measured, never painted, and the marquee never reaches it. This bites apps like RSS readers and daily-reflection-style apps whose content routinely exceeds ~40 lines.

The `*10` was itself a bump from `*2` back in #112 (2022); the limiting factor at the time was device memory / WebP payload size. Current-gen devices tolerate considerably larger payloads, so the original reason for the tight cap is much weaker.

## What changed

- `render/marquee.go`: the 8 occurrences of `m.Height*10` / `m.Width*10` now use a single named constant `MarqueeMaxContentScale` (= 20).
- Added a doc comment on the constant documenting the companion limits an author must also account for to actually reach the extra content (encoder `maxDuration`, and `DefaultMaxFrameCount`).

## Why 20 (and not higher)

A `Marquee` scrolls exactly **1px per frame**, so frame count ≈ `content_px + window`. Two existing limits bound how much of a taller child is actually reachable on screen:

- **Temporal** — the WebP/GIF encoder stops adding frames once cumulative time hits `maxDuration` (the dwell budget). Content longer than `dwell_ms / delay_ms` pixels is truncated mid-scroll regardless of this cap.
- **Frame count (hard)** — `DefaultMaxFrameCount = 2000` ⇒ a ceiling of ~1968px of travel (~246 lines of `tb-8`), independent of device size.

20× lands at roughly **one-third** of that 2000-frame hard ceiling (640px @ `height=32`), so it's a safe doubling that stays well within the existing limits rather than introducing a new effective ceiling.

Open to a different shape if maintainers prefer — e.g. capping the child dimension at `DefaultMaxFrameCount` px directly (an absolute cap that coincides with the real hard limit and is consistent across marquee/device sizes), or exposing a per-`Marquee` override in the schema. Happy to adjust.

## Validation

Built `old` (10×) and `new` (20×) binaries and rendered an 80-line vertical `Marquee` + `WrappedText` at unlimited duration (`-d 0`), so the spatial cap is the only limiter:

| | old (10×) | new (20×) | ratio |
|---|---|---|---|
| GIF frame count | 352 | 672 | **1.91×** |
| WebP size | 43,612 B | 84,174 B | 1.93× |
| Scrollable child height | 320px | 640px | 2.0× |
| Deepest line reached | ~L42 / 80 | **L80 / 80** | — |

Frame counts match the `content + window` model exactly: `352 = 320 + 32`, `672 = 640 + 32`. Before the change the marquee tops out around line 42 of 80 (the bottom half is unreachable); after, it scrolls the full text.

`go test ./render/...` passes.
