### PR TITLE
Fix memory leak in WebP decoder

### DIFF
--- a/render/image_webp_cgo.go
+++ b/render/image_webp_cgo.go
@@ -14,6 +14,7 @@ func (p *Image) InitFromWebP(data []byte) error {
 	if err != nil {
 		return fmt.Errorf("creating animation decoder: %w", err)
 	}
+	defer decoder.Close()
 
 	img, err := decoder.Decode()
 	if err != nil {


### PR DESCRIPTION
`InitFromWebP` created a `webp.AnimationDecoder` but never called `Close()`, resulting in a memory leak when decoding WebP images. I noticed this when an app I built that loads WebP images from an API was causing steady memory leaks on Railway. Switching to PNGs avoided the leak; this PR should hopefully fix it for good.

<img width="1564" height="714" alt="CleanShot 2026-06-13 at 13 47 48@2x" src="https://github.com/user-attachments/assets/c89eb899-f39d-4073-90e1-7b36cf1706cd" />
